### PR TITLE
Add operations widgets for integrations, team, and careers

### DIFF
--- a/src/components/CareersPipeline.tsx
+++ b/src/components/CareersPipeline.tsx
@@ -1,0 +1,89 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
+import { BriefcaseBusiness } from "lucide-react";
+
+const pipelineStages = [
+  {
+    name: "Applied",
+    count: 24,
+    change: "+5 this week",
+    progress: 65
+  },
+  {
+    name: "Interview",
+    count: 8,
+    change: "2 scheduled today",
+    progress: 45
+  },
+  {
+    name: "Offer",
+    count: 3,
+    change: "Awaiting signature",
+    progress: 20
+  }
+];
+
+const openRoles = [
+  {
+    title: "Product Manager",
+    location: "Remote",
+    applicants: 14
+  },
+  {
+    title: "Full-stack Engineer",
+    location: "Hybrid · Austin",
+    applicants: 9
+  }
+];
+
+export function CareersPipeline() {
+  return (
+    <Card className="shadow-card">
+      <CardHeader className="flex flex-row items-center justify-between space-y-0">
+        <CardTitle className="text-lg font-semibold flex items-center gap-2">
+          <BriefcaseBusiness className="h-5 w-5" />
+          Careers Pipeline
+        </CardTitle>
+        <Badge variant="outline" className="text-xs">Hiring</Badge>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        <div className="space-y-3">
+          {pipelineStages.map((stage) => (
+            <div key={stage.name} className="rounded-xl border border-border/60 bg-background/90 p-3">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-semibold text-foreground">{stage.name}</p>
+                  <p className="text-xs text-muted-foreground">{stage.change}</p>
+                </div>
+                <Badge variant="secondary" className="text-xs">
+                  {stage.count} candidates
+                </Badge>
+              </div>
+              <Progress value={stage.progress} className="mt-3" />
+            </div>
+          ))}
+        </div>
+
+        <div className="rounded-xl border border-dashed border-border/60 bg-muted/20 p-4">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Open roles
+          </p>
+          <div className="mt-3 space-y-3">
+            {openRoles.map((role) => (
+              <div key={role.title} className="flex items-center justify-between rounded-lg bg-background/80 px-3 py-2">
+                <div>
+                  <p className="text-sm font-medium text-foreground">{role.title}</p>
+                  <p className="text-xs text-muted-foreground">{role.location}</p>
+                </div>
+                <Badge variant="outline" className="text-xs">
+                  {role.applicants} applicants
+                </Badge>
+              </div>
+            ))}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/DropboxUsage.tsx
+++ b/src/components/DropboxUsage.tsx
@@ -1,0 +1,76 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import { Badge } from "@/components/ui/badge";
+import { Cloud, ExternalLink, FolderKanban } from "lucide-react";
+
+const sharedFolders = [
+  {
+    name: "Client handoffs",
+    path: "/Native/Clients/Handoffs",
+    updated: "Updated 6m ago"
+  },
+  {
+    name: "Product design",
+    path: "/Native/Product/Design",
+    updated: "Updated 1h ago"
+  },
+  {
+    name: "Contracts",
+    path: "/Native/Legal/Contracts",
+    updated: "Updated yesterday"
+  }
+];
+
+export function DropboxUsage() {
+  return (
+    <Card className="shadow-card">
+      <CardHeader className="space-y-1">
+        <CardTitle className="text-lg font-semibold flex items-center gap-2">
+          <Cloud className="h-5 w-5" />
+          Dropbox Workspace
+        </CardTitle>
+        <p className="text-xs text-muted-foreground">
+          Track shared folders, upload activity, and available storage at a glance.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="rounded-xl border border-border/60 bg-muted/20 p-4">
+          <div className="flex items-center justify-between text-sm font-semibold text-foreground">
+            <span>Storage usage</span>
+            <span>72% of 2 TB</span>
+          </div>
+          <Progress value={72} className="mt-3" />
+          <div className="mt-2 flex items-center justify-between text-xs text-muted-foreground">
+            <span>1.44 TB used</span>
+            <Badge variant="outline">Auto-archiving enabled</Badge>
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Shared folders
+          </p>
+          {sharedFolders.map((folder) => (
+            <div key={folder.name} className="flex items-center justify-between rounded-lg border border-border/60 bg-background/90 px-3 py-2">
+              <div className="flex items-start gap-3">
+                <div className="mt-1 flex h-8 w-8 items-center justify-center rounded-md bg-gradient-accent text-white">
+                  <FolderKanban className="h-4 w-4" />
+                </div>
+                <div>
+                  <p className="text-sm font-medium text-foreground">{folder.name}</p>
+                  <p className="text-xs text-muted-foreground">{folder.path}</p>
+                  <p className="text-xs text-muted-foreground/80">{folder.updated}</p>
+                </div>
+              </div>
+              <Button size="sm" variant="ghost" className="gap-1 text-xs">
+                Open
+                <ExternalLink className="h-3 w-3" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/IntegrationStatus.tsx
+++ b/src/components/IntegrationStatus.tsx
@@ -1,0 +1,85 @@
+import { CalendarDays, Cloud, RefreshCw, ShieldCheck } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+const integrations = [
+  {
+    name: "Google Calendar",
+    description: "Sync meetings, deadlines, and reminders across workspaces.",
+    status: "Connected",
+    lastSynced: "5 minutes ago",
+    icon: CalendarDays,
+    accent: "bg-gradient-primary",
+    actionLabel: "Manage"
+  },
+  {
+    name: "Microsoft 365",
+    description: "Two-way sync with Outlook calendars for hybrid teams.",
+    status: "Connected",
+    lastSynced: "12 minutes ago",
+    icon: RefreshCw,
+    accent: "bg-gradient-accent",
+    actionLabel: "Manage"
+  },
+  {
+    name: "Dropbox",
+    description: "Attach folders, collect uploads, and keep docs in sync.",
+    status: "Requires attention",
+    lastSynced: "Authentication expires in 2 days",
+    icon: Cloud,
+    accent: "bg-muted",
+    actionLabel: "Reconnect"
+  }
+];
+
+export function IntegrationStatus() {
+  return (
+    <Card className="shadow-card">
+      <CardHeader className="flex flex-row items-center justify-between space-y-0">
+        <CardTitle className="text-lg font-semibold">Integrations</CardTitle>
+        <ShieldCheck className="h-5 w-5 text-muted-foreground" />
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {integrations.map((integration) => {
+          const Icon = integration.icon;
+          const isHealthy = integration.status === "Connected";
+
+          return (
+            <div
+              key={integration.name}
+              className="flex items-start justify-between rounded-xl border border-border/60 bg-muted/20 p-4 transition-all hover:border-border hover:bg-background"
+            >
+              <div className="flex items-start space-x-3">
+                <div className={`flex h-10 w-10 items-center justify-center rounded-lg ${integration.accent}`}>
+                  <Icon className={`h-5 w-5 ${integration.accent === "bg-muted" ? "text-muted-foreground" : "text-white"}`} />
+                </div>
+                <div>
+                  <div className="flex items-center gap-2">
+                    <p className="text-sm font-semibold text-foreground">{integration.name}</p>
+                    <Badge variant={isHealthy ? "secondary" : "destructive"}>
+                      {integration.status}
+                    </Badge>
+                  </div>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {integration.description}
+                  </p>
+                  <p className="mt-2 text-xs text-muted-foreground/80">
+                    Last sync: {integration.lastSynced}
+                  </p>
+                </div>
+              </div>
+              <Button
+                size="sm"
+                variant={isHealthy ? "outline" : "default"}
+                className={isHealthy ? "" : "bg-gradient-primary hover:opacity-90"}
+              >
+                {integration.actionLabel}
+              </Button>
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/TeamOverview.tsx
+++ b/src/components/TeamOverview.tsx
@@ -1,0 +1,116 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Shield, UserPlus2 } from "lucide-react";
+
+const members = [
+  {
+    name: "Sarah Johnson",
+    role: "Founder",
+    initials: "SJ",
+    avatar: null,
+    status: "Online"
+  },
+  {
+    name: "Mike Chen",
+    role: "Operations",
+    initials: "MC",
+    avatar: null,
+    status: "Reviewing tasks"
+  },
+  {
+    name: "Emma Davis",
+    role: "Recruiter",
+    initials: "ED",
+    avatar: null,
+    status: "Interview today"
+  }
+];
+
+const pendingInvites = [
+  {
+    email: "alex@native.co",
+    role: "Manager",
+    sent: "Sent 1 day ago"
+  },
+  {
+    email: "lisa@native.co",
+    role: "Client",
+    sent: "Sent 3 hours ago"
+  }
+];
+
+export function TeamOverview() {
+  return (
+    <Card className="shadow-card">
+      <CardHeader className="flex flex-row items-center justify-between space-y-0">
+        <CardTitle className="text-lg font-semibold">Team Management</CardTitle>
+        <Button size="sm" variant="outline" className="gap-2">
+          <UserPlus2 className="h-4 w-4" />
+          Invite
+        </Button>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-3">
+          {members.map((member) => (
+            <div key={member.name} className="flex items-center justify-between rounded-lg border border-border/60 bg-background/80 p-3">
+              <div className="flex items-center space-x-3">
+                <Avatar className="h-9 w-9">
+                  <AvatarImage src={member.avatar || undefined} alt={member.name} />
+                  <AvatarFallback className="bg-gradient-accent text-white text-sm">
+                    {member.initials}
+                  </AvatarFallback>
+                </Avatar>
+                <div>
+                  <p className="text-sm font-medium text-foreground">{member.name}</p>
+                  <p className="text-xs text-muted-foreground">{member.role}</p>
+                </div>
+              </div>
+              <Badge variant="secondary" className="text-xs">
+                {member.status}
+              </Badge>
+            </div>
+          ))}
+        </div>
+
+        <div className="rounded-xl border border-dashed border-border/60 bg-muted/20 p-4">
+          <div className="flex items-start space-x-3">
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-gradient-primary text-white">
+              <Shield className="h-4 w-4" />
+            </div>
+            <div>
+              <p className="text-sm font-semibold text-foreground">Security snapshot</p>
+              <p className="text-xs text-muted-foreground">
+                2FA enforced for admins • SSO ready • 3 active API tokens
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Pending invites
+          </p>
+          <div className="mt-3 space-y-2">
+            {pendingInvites.map((invite) => (
+              <div key={invite.email} className="flex items-center justify-between rounded-lg bg-muted/40 px-3 py-2">
+                <div>
+                  <p className="text-sm font-medium text-foreground">{invite.email}</p>
+                  <p className="text-xs text-muted-foreground">{invite.role} · {invite.sent}</p>
+                </div>
+                <Button size="sm" variant="ghost" className="text-xs">
+                  Resend
+                </Button>
+              </div>
+            ))}
+          </div>
+        </div>
+      </CardContent>
+      <CardFooter className="flex items-center justify-between text-xs text-muted-foreground">
+        <span>8 active members</span>
+        <span>Roles: Admin · Manager · Creator · Client</span>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => {
   return (

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -4,6 +4,10 @@ import { TasksOverview } from "@/components/TasksOverview";
 import { CalendarOverview } from "@/components/CalendarOverview";
 import { QuickActions } from "@/components/QuickActions";
 import { RecentActivity } from "@/components/RecentActivity";
+import { IntegrationStatus } from "@/components/IntegrationStatus";
+import { TeamOverview } from "@/components/TeamOverview";
+import { CareersPipeline } from "@/components/CareersPipeline";
+import { DropboxUsage } from "@/components/DropboxUsage";
 import { Button } from "@/components/ui/button";
 import { Bell, Settings, Search } from "lucide-react";
 
@@ -55,6 +59,18 @@ const Index = () => {
             <div>
               <h2 className="text-xl font-semibold mb-4">Quick Actions</h2>
               <QuickActions />
+            </div>
+          </div>
+
+          {/* Operations Hub */}
+          <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+            <div className="space-y-6 xl:col-span-2">
+              <IntegrationStatus />
+              <CareersPipeline />
+            </div>
+            <div className="space-y-6">
+              <TeamOverview />
+              <DropboxUsage />
             </div>
           </div>
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
   darkMode: ["class"],
@@ -59,17 +60,17 @@ export default {
         },
       },
       backgroundImage: {
-        'gradient-primary': 'var(--gradient-primary)',
-        'gradient-subtle': 'var(--gradient-subtle)',
-        'gradient-accent': 'var(--gradient-accent)',
+        "gradient-primary": "var(--gradient-primary)",
+        "gradient-subtle": "var(--gradient-subtle)",
+        "gradient-accent": "var(--gradient-accent)",
       },
       boxShadow: {
-        'card': 'var(--shadow-card)',
-        'elevated': 'var(--shadow-elevated)',
-        'glow': 'var(--shadow-glow)',
+        card: "var(--shadow-card)",
+        elevated: "var(--shadow-elevated)",
+        glow: "var(--shadow-glow)",
       },
       transitionTimingFunction: {
-        'smooth': 'var(--transition-smooth)',
+        smooth: "var(--transition-smooth)",
       },
       borderRadius: {
         lg: "var(--radius)",
@@ -100,5 +101,5 @@ export default {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add integration, team management, careers, and Dropbox widgets to the dashboard layout
- refactor shared UI utilities to satisfy lint and remove CommonJS usage in Tailwind config
- enhance dashboard layout to surface CRM ops insights inspired by ClickUp-style workflows

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d502dddcd88331bcb74f2f672dafba