### PR TITLE
Add working routes and interactions for dashboard buttons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,15 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
+import Tasks from "./pages/Tasks";
+import Calendar from "./pages/Calendar";
+import People from "./pages/People";
+import Files from "./pages/Files";
+import Careers from "./pages/Careers";
+import Settings from "./pages/Settings";
+import Search from "./pages/Search";
+import Notifications from "./pages/Notifications";
+import Demo from "./pages/Demo";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -16,6 +25,15 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/tasks" element={<Tasks />} />
+          <Route path="/calendar" element={<Calendar />} />
+          <Route path="/people" element={<People />} />
+          <Route path="/files" element={<Files />} />
+          <Route path="/careers" element={<Careers />} />
+          <Route path="/settings" element={<Settings />} />
+          <Route path="/search" element={<Search />} />
+          <Route path="/notifications" element={<Notifications />} />
+          <Route path="/demo" element={<Demo />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -1,5 +1,4 @@
-import { useState } from "react";
-import { NavLink, useLocation } from "react-router-dom";
+import { NavLink, useLocation, useNavigate } from "react-router-dom";
 import {
   LayoutDashboard,
   CheckSquare,
@@ -48,6 +47,7 @@ const settingsItems = [
 export function AppSidebar() {
   const { state, toggleSidebar } = useSidebar();
   const location = useLocation();
+  const navigate = useNavigate();
   const currentPath = location.pathname;
   const collapsed = state === "collapsed";
 
@@ -84,7 +84,10 @@ export function AppSidebar() {
         
         {!collapsed && (
           <div className="mt-4 space-y-2">
-            <Button className="w-full bg-gradient-primary hover:opacity-90 shadow-sm">
+            <Button
+              className="w-full bg-gradient-primary hover:opacity-90 shadow-sm"
+              onClick={() => navigate("/tasks")}
+            >
               <Plus className="h-4 w-4 mr-2" />
               New Task
             </Button>
@@ -93,6 +96,12 @@ export function AppSidebar() {
               <input
                 type="text"
                 placeholder="Search..."
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    event.preventDefault();
+                    navigate("/search", { state: { query: event.currentTarget.value } });
+                  }
+                }}
                 className="w-full pl-10 pr-4 py-2 bg-background border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary/20"
               />
             </div>
@@ -179,7 +188,14 @@ export function AppSidebar() {
             </div>
           )}
           <div className="relative">
-            <Bell className="h-4 w-4 text-sidebar-foreground/60 hover:text-sidebar-foreground cursor-pointer" />
+            <button
+              type="button"
+              onClick={() => navigate("/notifications")}
+              aria-label="View notifications"
+              className="text-sidebar-foreground/60 transition-colors hover:text-sidebar-foreground"
+            >
+              <Bell className="h-4 w-4" />
+            </button>
             <div className="absolute -top-1 -right-1 w-2 h-2 bg-accent rounded-full"></div>
           </div>
         </div>

--- a/src/components/DropboxUsage.tsx
+++ b/src/components/DropboxUsage.tsx
@@ -1,7 +1,10 @@
+import { useNavigate } from "react-router-dom";
+
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { Badge } from "@/components/ui/badge";
+import { useToast } from "@/hooks/use-toast";
 import { Cloud, ExternalLink, FolderKanban } from "lucide-react";
 
 const sharedFolders = [
@@ -23,6 +26,9 @@ const sharedFolders = [
 ];
 
 export function DropboxUsage() {
+  const navigate = useNavigate();
+  const { toast } = useToast();
+
   return (
     <Card className="shadow-card">
       <CardHeader className="space-y-1">
@@ -63,7 +69,18 @@ export function DropboxUsage() {
                   <p className="text-xs text-muted-foreground/80">{folder.updated}</p>
                 </div>
               </div>
-              <Button size="sm" variant="ghost" className="gap-1 text-xs">
+              <Button
+                size="sm"
+                variant="ghost"
+                className="gap-1 text-xs"
+                onClick={() => {
+                  navigate("/files", { state: { folder: folder.name } });
+                  toast({
+                    title: "Opening folder",
+                    description: `${folder.name} is highlighted in the Files view.`,
+                  });
+                }}
+              >
                 Open
                 <ExternalLink className="h-3 w-3" />
               </Button>

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,0 +1,19 @@
+import { ReactNode } from "react";
+
+interface PageHeaderProps {
+  title: string;
+  description: string;
+  actions?: ReactNode;
+}
+
+export function PageHeader({ title, description, actions }: PageHeaderProps) {
+  return (
+    <div className="flex flex-col gap-4 border-b border-border/50 bg-white/70 p-6 backdrop-blur-sm sm:flex-row sm:items-center sm:justify-between">
+      <div className="space-y-1">
+        <h1 className="text-2xl font-semibold text-foreground">{title}</h1>
+        <p className="text-muted-foreground max-w-2xl text-sm sm:text-base">{description}</p>
+      </div>
+      {actions && <div className="flex items-center gap-2">{actions}</div>}
+    </div>
+  );
+}

--- a/src/components/QuickActions.tsx
+++ b/src/components/QuickActions.tsx
@@ -1,53 +1,65 @@
+import { useNavigate } from "react-router-dom";
+
 import { Plus, UserPlus, FileText, Calendar, Upload, Briefcase } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-
-const quickActions = [
-  {
-    icon: Plus,
-    label: "New Task",
-    description: "Create a task",
-    onClick: () => console.log("New task"),
-    variant: "default" as const
-  },
-  {
-    icon: UserPlus,
-    label: "Add Contact",
-    description: "Add person",
-    onClick: () => console.log("Add contact"),
-    variant: "outline" as const
-  },
-  {
-    icon: Calendar,
-    label: "Schedule Meeting",
-    description: "Book time",
-    onClick: () => console.log("Schedule meeting"),
-    variant: "outline" as const
-  },
-  {
-    icon: FileText,
-    label: "New Document",
-    description: "Create doc",
-    onClick: () => console.log("New document"),
-    variant: "outline" as const
-  },
-  {
-    icon: Upload,
-    label: "Upload File",
-    description: "Add to Dropbox",
-    onClick: () => console.log("Upload file"),
-    variant: "outline" as const
-  },
-  {
-    icon: Briefcase,
-    label: "Post Job",
-    description: "Hire talent",
-    onClick: () => console.log("Post job"),
-    variant: "outline" as const
-  }
-];
+import { useToast } from "@/hooks/use-toast";
 
 export function QuickActions() {
+  const navigate = useNavigate();
+  const { toast } = useToast();
+
+  const actions = [
+    {
+      icon: Plus,
+      label: "New Task",
+      description: "Create a task",
+      onClick: () => navigate("/tasks"),
+      variant: "default" as const,
+    },
+    {
+      icon: UserPlus,
+      label: "Add Contact",
+      description: "Add person",
+      onClick: () => navigate("/people"),
+      variant: "outline" as const,
+    },
+    {
+      icon: Calendar,
+      label: "Schedule Meeting",
+      description: "Book time",
+      onClick: () => navigate("/calendar"),
+      variant: "outline" as const,
+    },
+    {
+      icon: FileText,
+      label: "New Document",
+      description: "Create doc",
+      onClick: () => navigate("/files"),
+      variant: "outline" as const,
+    },
+    {
+      icon: Upload,
+      label: "Upload File",
+      description: "Add to Dropbox",
+      onClick: () => {
+        navigate("/files");
+        toast({
+          title: "Upload",
+          description: "Connect Dropbox to upload directly from this view.",
+        });
+      },
+      variant: "outline" as const,
+    },
+    {
+      icon: Briefcase,
+      label: "Post Job",
+      description: "Hire talent",
+      onClick: () => navigate("/careers"),
+      variant: "outline" as const,
+    },
+  ];
+
   return (
     <Card className="shadow-card">
       <CardHeader>
@@ -55,7 +67,7 @@ export function QuickActions() {
       </CardHeader>
       <CardContent>
         <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
-          {quickActions.map((action, index) => (
+          {actions.map((action, index) => (
             <Button
               key={index}
               variant={action.variant}

--- a/src/components/TeamOverview.tsx
+++ b/src/components/TeamOverview.tsx
@@ -1,7 +1,10 @@
+import { useNavigate } from "react-router-dom";
+
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { useToast } from "@/hooks/use-toast";
 import { Shield, UserPlus2 } from "lucide-react";
 
 const members = [
@@ -42,11 +45,19 @@ const pendingInvites = [
 ];
 
 export function TeamOverview() {
+  const navigate = useNavigate();
+  const { toast } = useToast();
+
   return (
     <Card className="shadow-card">
       <CardHeader className="flex flex-row items-center justify-between space-y-0">
         <CardTitle className="text-lg font-semibold">Team Management</CardTitle>
-        <Button size="sm" variant="outline" className="gap-2">
+        <Button
+          size="sm"
+          variant="outline"
+          className="gap-2"
+          onClick={() => navigate("/people")}
+        >
           <UserPlus2 className="h-4 w-4" />
           Invite
         </Button>
@@ -99,7 +110,17 @@ export function TeamOverview() {
                   <p className="text-sm font-medium text-foreground">{invite.email}</p>
                   <p className="text-xs text-muted-foreground">{invite.role} · {invite.sent}</p>
                 </div>
-                <Button size="sm" variant="ghost" className="text-xs">
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="text-xs"
+                  onClick={() =>
+                    toast({
+                      title: "Invite resent",
+                      description: `${invite.email} has been notified again.`,
+                    })
+                  }
+                >
                   Resend
                 </Button>
               </div>

--- a/src/components/WelcomeBanner.tsx
+++ b/src/components/WelcomeBanner.tsx
@@ -1,3 +1,5 @@
+import { Link } from "react-router-dom";
+
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { ArrowRight, Sparkles } from "lucide-react";
@@ -31,12 +33,14 @@ export function WelcomeBanner() {
               </p>
             </div>
             <div className="flex space-x-3">
-              <Button className="bg-gradient-primary hover:opacity-90 shadow-glow">
-                Get Started
-                <ArrowRight className="ml-2 h-4 w-4" />
+              <Button asChild className="bg-gradient-primary hover:opacity-90 shadow-glow">
+                <Link to="/tasks">
+                  Get Started
+                  <ArrowRight className="ml-2 h-4 w-4" />
+                </Link>
               </Button>
-              <Button variant="outline">
-                Watch Demo
+              <Button asChild variant="outline">
+                <Link to="/demo">Watch Demo</Link>
               </Button>
             </div>
           </div>

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -1,0 +1,138 @@
+import { DashboardLayout } from "@/components/DashboardLayout";
+import { PageHeader } from "@/components/PageHeader";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { useToast } from "@/hooks/use-toast";
+import { Calendar as CalendarIcon, Plus, Video, Users } from "lucide-react";
+
+const meetings = [
+  {
+    title: "Customer success sync",
+    time: "09:30 - 10:15",
+    type: "Zoom",
+    attendees: "5 attendees",
+  },
+  {
+    title: "Product roadmap review",
+    time: "11:00 - 12:00",
+    type: "Hybrid",
+    attendees: "12 attendees",
+  },
+  {
+    title: "Candidate interview",
+    time: "14:30 - 15:00",
+    type: "Google Meet",
+    attendees: "Panel with HR",
+  },
+];
+
+const events = [
+  { day: "Mon", focus: "Operations", count: 5 },
+  { day: "Tue", focus: "Product", count: 4 },
+  { day: "Wed", focus: "Sales", count: 6 },
+  { day: "Thu", focus: "Hiring", count: 3 },
+  { day: "Fri", focus: "Finance", count: 4 },
+];
+
+const Calendar = () => {
+  const { toast } = useToast();
+
+  const handleNewMeeting = () => {
+    toast({
+      title: "Schedule meeting",
+      description: "Calendar integrations will open in a connected account.",
+    });
+  };
+
+  const handleInviteTeam = () => {
+    toast({
+      title: "Invite teammates",
+      description: "Share availability from the team directory.",
+    });
+  };
+
+  return (
+    <DashboardLayout>
+      <div className="flex min-h-screen flex-col bg-gradient-subtle">
+        <PageHeader
+          title="Calendar"
+          description="Review upcoming meetings, prepare agendas, and coordinate availability across teams."
+          actions={(
+            <>
+              <Button variant="outline" size="sm" onClick={handleInviteTeam}>
+                <Users className="mr-2 h-4 w-4" />
+                Share availability
+              </Button>
+              <Button size="sm" onClick={handleNewMeeting} className="bg-gradient-primary text-white shadow-glow">
+                <Plus className="mr-2 h-4 w-4" />
+                New meeting
+              </Button>
+            </>
+          )}
+        />
+
+        <div className="grid gap-6 p-6 lg:grid-cols-[2fr,1fr]">
+          <Card className="shadow-card">
+            <CardHeader className="flex items-center justify-between border-b border-border/60 pb-4">
+              <CardTitle className="text-lg font-semibold text-foreground">Today's agenda</CardTitle>
+              <Badge variant="secondary" className="gap-1 text-xs">
+                <CalendarIcon className="h-4 w-4" />
+                3 meetings
+              </Badge>
+            </CardHeader>
+            <CardContent className="space-y-4 pt-4">
+              {meetings.map((meeting) => (
+                <div key={meeting.title} className="rounded-xl border border-border/60 bg-white/70 p-4 shadow-card/30">
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                      <p className="text-sm font-semibold text-foreground">{meeting.title}</p>
+                      <p className="text-xs text-muted-foreground">{meeting.attendees}</p>
+                    </div>
+                    <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                      <Video className="h-4 w-4" />
+                      {meeting.type}
+                    </div>
+                  </div>
+                  <div className="mt-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    {meeting.time}
+                  </div>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+
+          <div className="space-y-6">
+            <Card className="shadow-card">
+              <CardHeader>
+                <CardTitle className="text-lg font-semibold text-foreground">Focus for the week</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {events.map((event) => (
+                  <div key={event.day} className="flex items-center justify-between rounded-lg bg-muted/30 px-3 py-2 text-sm">
+                    <span className="font-semibold text-foreground">{event.day}</span>
+                    <span className="text-muted-foreground">{event.focus}</span>
+                    <Badge variant="outline">{event.count} events</Badge>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+
+            <Card className="shadow-card">
+              <CardHeader>
+                <CardTitle className="text-lg font-semibold text-foreground">Meeting reminders</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm text-muted-foreground">
+                <p>• Send agenda for the product review.</p>
+                <p>• Share candidate resume with panel.</p>
+                <p>• Confirm follow-up notes after customer sync.</p>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+};
+
+export default Calendar;

--- a/src/pages/Careers.tsx
+++ b/src/pages/Careers.tsx
@@ -1,0 +1,127 @@
+import { DashboardLayout } from "@/components/DashboardLayout";
+import { PageHeader } from "@/components/PageHeader";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { useToast } from "@/hooks/use-toast";
+import { Plus, Settings, ClipboardList } from "lucide-react";
+
+const openings = [
+  {
+    title: "Implementation Specialist",
+    location: "Remote · North America",
+    pipeline: "14 candidates",
+    stage: "Interviews",
+  },
+  {
+    title: "Customer Success Manager",
+    location: "Austin, TX",
+    pipeline: "22 candidates",
+    stage: "Reviewing",
+  },
+  {
+    title: "Revenue Operations Analyst",
+    location: "Remote",
+    pipeline: "9 candidates",
+    stage: "Sourcing",
+  },
+];
+
+const playbooks = [
+  { name: "Interview scorecard", type: "Template", updated: "Updated yesterday" },
+  { name: "Candidate outreach", type: "Workflow", updated: "Updated 2 days ago" },
+  { name: "Offer approval", type: "Process", updated: "Updated last week" },
+];
+
+const Careers = () => {
+  const { toast } = useToast();
+
+  const handleNewOpening = () => {
+    toast({
+      title: "Post a job",
+      description: "Sync role details to job boards and your career site.",
+    });
+  };
+
+  const handleConfigure = () => {
+    toast({
+      title: "Configure pipeline",
+      description: "Customize stages, approvers, and automation.",
+    });
+  };
+
+  return (
+    <DashboardLayout>
+      <div className="flex min-h-screen flex-col bg-gradient-subtle">
+        <PageHeader
+          title="Careers"
+          description="Manage open roles, candidate pipelines, and hiring playbooks across your teams."
+          actions={(
+            <>
+              <Button variant="outline" size="sm" onClick={handleConfigure}>
+                <Settings className="mr-2 h-4 w-4" />
+                Configure pipeline
+              </Button>
+              <Button size="sm" onClick={handleNewOpening} className="bg-gradient-primary text-white shadow-glow">
+                <Plus className="mr-2 h-4 w-4" />
+                Post job
+              </Button>
+            </>
+          )}
+        />
+
+        <div className="grid gap-6 p-6 lg:grid-cols-[2fr,1fr]">
+          <Card className="shadow-card">
+            <CardHeader className="border-b border-border/60 pb-4">
+              <CardTitle className="text-lg font-semibold text-foreground">Open roles</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4 pt-4">
+              {openings.map((opening) => (
+                <div key={opening.title} className="rounded-xl border border-border/60 bg-white/70 p-4 shadow-card/30">
+                  <div className="flex items-start justify-between">
+                    <div>
+                      <p className="text-sm font-semibold text-foreground">{opening.title}</p>
+                      <p className="text-xs text-muted-foreground">{opening.location}</p>
+                    </div>
+                    <Badge variant="secondary" className="text-xs">
+                      {opening.stage}
+                    </Badge>
+                  </div>
+                  <div className="mt-3 flex items-center justify-between text-xs text-muted-foreground">
+                    <span>{opening.pipeline}</span>
+                    <span>Hiring manager review</span>
+                  </div>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+
+          <Card className="shadow-card">
+            <CardHeader>
+              <CardTitle className="text-lg font-semibold text-foreground">Playbooks</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {playbooks.map((playbook) => (
+                <div key={playbook.name} className="flex items-center justify-between rounded-lg bg-muted/30 px-3 py-2">
+                  <div>
+                    <p className="text-sm font-semibold text-foreground">{playbook.name}</p>
+                    <p className="text-xs text-muted-foreground">{playbook.type}</p>
+                  </div>
+                  <Badge variant="outline" className="gap-1 text-xs">
+                    <ClipboardList className="h-3 w-3" />
+                    {playbook.updated}
+                  </Badge>
+                </div>
+              ))}
+              <p className="text-xs text-muted-foreground">
+                Playbooks automatically sync to hiring managers and interviewers.
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+};
+
+export default Careers;

--- a/src/pages/Demo.tsx
+++ b/src/pages/Demo.tsx
@@ -1,0 +1,66 @@
+import { DashboardLayout } from "@/components/DashboardLayout";
+import { PageHeader } from "@/components/PageHeader";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/hooks/use-toast";
+import { Play, Download } from "lucide-react";
+
+const Demo = () => {
+  const { toast } = useToast();
+
+  const handleDownload = () => {
+    toast({
+      title: "Demo deck downloaded",
+      description: "Check your downloads folder for the latest presentation.",
+    });
+  };
+
+  const handleWatch = () => {
+    toast({
+      title: "Demo starting",
+      description: "Streaming the interactive product tour.",
+    });
+  };
+
+  return (
+    <DashboardLayout>
+      <div className="flex min-h-screen flex-col bg-gradient-subtle">
+        <PageHeader
+          title="Product demo"
+          description="Explore how Native CRM connects tasks, files, and operations in one collaborative workspace."
+        />
+
+        <div className="p-6">
+          <Card className="overflow-hidden shadow-card">
+            <CardHeader className="space-y-3">
+              <CardTitle className="text-lg font-semibold text-foreground">Interactive tour</CardTitle>
+              <p className="text-sm text-muted-foreground">
+                Watch a guided walkthrough or download the executive summary deck to share with your team.
+              </p>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="aspect-video overflow-hidden rounded-xl border border-border/60 bg-muted/40">
+                <div className="flex h-full flex-col items-center justify-center space-y-3 text-muted-foreground">
+                  <Play className="h-12 w-12" />
+                  <p className="text-sm">Video preview coming soon.</p>
+                </div>
+              </div>
+              <div className="flex flex-col gap-3 sm:flex-row">
+                <Button onClick={handleWatch} className="bg-gradient-primary text-white shadow-glow">
+                  <Play className="mr-2 h-4 w-4" />
+                  Watch demo
+                </Button>
+                <Button variant="outline" onClick={handleDownload}>
+                  <Download className="mr-2 h-4 w-4" />
+                  Download deck
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+};
+
+export default Demo;

--- a/src/pages/Files.tsx
+++ b/src/pages/Files.tsx
@@ -1,0 +1,159 @@
+import { useMemo } from "react";
+import { useLocation } from "react-router-dom";
+
+import { DashboardLayout } from "@/components/DashboardLayout";
+import { PageHeader } from "@/components/PageHeader";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { useToast } from "@/hooks/use-toast";
+import { FolderOpen, Upload, Filter, FileText, Share2 } from "lucide-react";
+
+const folders = [
+  {
+    name: "Client handoffs",
+    path: "/Native/Clients/Handoffs",
+    files: 24,
+    updated: "Updated 6m ago",
+  },
+  {
+    name: "Product design",
+    path: "/Native/Product/Design",
+    files: 18,
+    updated: "Updated 1h ago",
+  },
+  {
+    name: "Contracts",
+    path: "/Native/Legal/Contracts",
+    files: 12,
+    updated: "Updated yesterday",
+  },
+];
+
+const documents = [
+  { name: "FY25 OKRs.pdf", owner: "Sarah Johnson", updated: "Edited today" },
+  { name: "Client Rollout Checklist.docx", owner: "Mike Chen", updated: "Edited 2 hours ago" },
+  { name: "Hiring Scorecard.xlsx", owner: "Emma Davis", updated: "Edited yesterday" },
+  { name: "Security Review.md", owner: "Alex Morgan", updated: "Edited 2 days ago" },
+];
+
+const Files = () => {
+  const location = useLocation();
+  const { toast } = useToast();
+
+  const highlightedFolder = useMemo(() => {
+    const state = location.state as { folder?: string } | null;
+    if (state?.folder) {
+      return folders.find((folder) => folder.name === state.folder)?.name ?? null;
+    }
+    return null;
+  }, [location.state]);
+
+  const handleUpload = () => {
+    toast({
+      title: "Upload file",
+      description: "Drag and drop files or connect to Dropbox to sync instantly.",
+    });
+  };
+
+  const handleFilter = () => {
+    toast({
+      title: "Filter files",
+      description: "Filter by owner, status, or last activity.",
+    });
+  };
+
+  const handleShare = (documentName: string) => {
+    toast({
+      title: "Share document",
+      description: `${documentName} is ready to share with the selected workspace.`,
+    });
+  };
+
+  return (
+    <DashboardLayout>
+      <div className="flex min-h-screen flex-col bg-gradient-subtle">
+        <PageHeader
+          title="Files"
+          description="Browse recent documents and shared folders from your connected storage providers."
+          actions={(
+            <>
+              <Button variant="outline" size="sm" onClick={handleFilter}>
+                <Filter className="mr-2 h-4 w-4" />
+                Filter
+              </Button>
+              <Button size="sm" onClick={handleUpload} className="bg-gradient-primary text-white shadow-glow">
+                <Upload className="mr-2 h-4 w-4" />
+                Upload
+              </Button>
+            </>
+          )}
+        />
+
+        <div className="grid gap-6 p-6 lg:grid-cols-[1.2fr,1fr]">
+          <Card className="shadow-card">
+            <CardHeader className="border-b border-border/60 pb-4">
+              <CardTitle className="text-lg font-semibold text-foreground">Shared folders</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 pt-4">
+              {folders.map((folder) => (
+                <div
+                  key={folder.path}
+                  className={`flex items-start justify-between rounded-xl border border-border/60 bg-white/70 p-4 shadow-card/30 transition-all ${highlightedFolder === folder.name ? "ring-2 ring-accent/60" : ""}`}
+                >
+                  <div className="flex items-start gap-3">
+                    <div className="mt-1 flex h-9 w-9 items-center justify-center rounded-lg bg-gradient-accent text-white">
+                      <FolderOpen className="h-4 w-4" />
+                    </div>
+                    <div>
+                      <p className="text-sm font-semibold text-foreground">{folder.name}</p>
+                      <p className="text-xs text-muted-foreground">{folder.path}</p>
+                      <p className="text-xs text-muted-foreground/80">{folder.updated}</p>
+                    </div>
+                  </div>
+                  <Badge variant="secondary" className="text-xs">
+                    {folder.files} files
+                  </Badge>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+
+          <Card className="shadow-card">
+            <CardHeader className="border-b border-border/60 pb-4">
+              <CardTitle className="text-lg font-semibold text-foreground">Recent documents</CardTitle>
+            </CardHeader>
+            <CardContent className="pt-4">
+              <ScrollArea className="h-80 pr-4">
+                <div className="space-y-3">
+                  {documents.map((document) => (
+                    <div key={document.name} className="flex items-center justify-between rounded-lg bg-muted/30 px-3 py-2">
+                      <div>
+                        <p className="text-sm font-semibold text-foreground">{document.name}</p>
+                        <p className="text-xs text-muted-foreground">Owned by {document.owner}</p>
+                        <p className="text-xs text-muted-foreground/80">{document.updated}</p>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Badge variant="outline" className="gap-1 text-xs">
+                          <FileText className="h-3 w-3" />
+                          Preview
+                        </Badge>
+                        <Button size="sm" variant="outline" className="gap-2" onClick={() => handleShare(document.name)}>
+                          <Share2 className="h-4 w-4" />
+                          Share
+                        </Button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </ScrollArea>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+};
+
+export default Files;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,3 +1,5 @@
+import { useNavigate } from "react-router-dom";
+
 import { DashboardLayout } from "@/components/DashboardLayout";
 import { WelcomeBanner } from "@/components/WelcomeBanner";
 import { TasksOverview } from "@/components/TasksOverview";
@@ -12,6 +14,8 @@ import { Button } from "@/components/ui/button";
 import { Bell, Settings, Search } from "lucide-react";
 
 const Index = () => {
+  const navigate = useNavigate();
+
   return (
     <DashboardLayout>
       <div className="min-h-screen bg-gradient-subtle">
@@ -24,14 +28,14 @@ const Index = () => {
                 <p className="text-muted-foreground">Welcome back! Here's what's happening today.</p>
               </div>
               <div className="flex items-center space-x-3">
-                <Button variant="outline" size="sm">
+                <Button variant="outline" size="sm" onClick={() => navigate("/search")}>
                   <Search className="h-4 w-4 mr-2" />
                   Search
                 </Button>
-                <Button variant="outline" size="sm">
+                <Button variant="outline" size="sm" onClick={() => navigate("/notifications")}>
                   <Bell className="h-4 w-4" />
                 </Button>
-                <Button variant="outline" size="sm">
+                <Button variant="outline" size="sm" onClick={() => navigate("/settings")}>
                   <Settings className="h-4 w-4" />
                 </Button>
               </div>

--- a/src/pages/Notifications.tsx
+++ b/src/pages/Notifications.tsx
@@ -1,0 +1,77 @@
+import { DashboardLayout } from "@/components/DashboardLayout";
+import { PageHeader } from "@/components/PageHeader";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/hooks/use-toast";
+import { BellRing, CheckCheck } from "lucide-react";
+
+const updates = [
+  {
+    title: "Sarah Johnson completed 'Onboarding playbook'",
+    time: "Just now",
+    type: "Task",
+  },
+  {
+    title: "Mike Chen shared 'Q4 client review deck'",
+    time: "15 minutes ago",
+    type: "File",
+  },
+  {
+    title: "Emma Davis scheduled an interview with Alex",
+    time: "1 hour ago",
+    type: "Calendar",
+  },
+];
+
+const Notifications = () => {
+  const { toast } = useToast();
+
+  const handleMarkAll = () => {
+    toast({
+      title: "Notifications cleared",
+      description: "You're all caught up on workspace activity.",
+    });
+  };
+
+  return (
+    <DashboardLayout>
+      <div className="flex min-h-screen flex-col bg-gradient-subtle">
+        <PageHeader
+          title="Notifications"
+          description="Review recent activity across tasks, files, and collaboration tools."
+          actions={(
+            <Button variant="outline" size="sm" onClick={handleMarkAll}>
+              <CheckCheck className="mr-2 h-4 w-4" />
+              Mark all as read
+            </Button>
+          )}
+        />
+
+        <div className="p-6">
+          <Card className="shadow-card">
+            <CardHeader className="flex items-center gap-2">
+              <BellRing className="h-5 w-5 text-accent" />
+              <CardTitle className="text-lg font-semibold text-foreground">Recent updates</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {updates.map((update) => (
+                <div key={update.title} className="flex flex-col gap-1 rounded-lg border border-border/60 bg-white/70 p-4 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <p className="text-sm font-semibold text-foreground">{update.title}</p>
+                    <p className="text-xs text-muted-foreground">{update.time}</p>
+                  </div>
+                  <Badge variant="secondary" className="self-start text-xs sm:self-auto">
+                    {update.type}
+                  </Badge>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+};
+
+export default Notifications;

--- a/src/pages/People.tsx
+++ b/src/pages/People.tsx
@@ -1,0 +1,149 @@
+import { DashboardLayout } from "@/components/DashboardLayout";
+import { PageHeader } from "@/components/PageHeader";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { useToast } from "@/hooks/use-toast";
+import { Filter, Mail, UserPlus } from "lucide-react";
+
+const team = [
+  {
+    name: "Sarah Johnson",
+    title: "Founder",
+    email: "sarah@native.co",
+    status: "Online",
+    initials: "SJ",
+    avatar: null,
+  },
+  {
+    name: "Mike Chen",
+    title: "Operations Lead",
+    email: "mike@native.co",
+    status: "Reviewing pipeline",
+    initials: "MC",
+    avatar: null,
+  },
+  {
+    name: "Emma Davis",
+    title: "Recruiter",
+    email: "emma@native.co",
+    status: "Interview scheduled",
+    initials: "ED",
+    avatar: null,
+  },
+  {
+    name: "Alex Morgan",
+    title: "Client Partner",
+    email: "alex@native.co",
+    status: "Out of office",
+    initials: "AM",
+    avatar: null,
+  },
+];
+
+const invites = [
+  { email: "lisa@native.co", role: "Client", sent: "Sent 1 hour ago" },
+  { email: "drew@native.co", role: "Manager", sent: "Sent yesterday" },
+];
+
+const People = () => {
+  const { toast } = useToast();
+
+  const handleInvite = () => {
+    toast({
+      title: "Invite teammate",
+      description: "Send an invite with role selection and SSO provisioning.",
+    });
+  };
+
+  const handleFilter = () => {
+    toast({
+      title: "Filter directory",
+      description: "Use status, role, or segment to refine your view.",
+    });
+  };
+
+  const handleMessage = (name: string) => {
+    toast({
+      title: `Message sent to ${name}`,
+      description: "They will receive it in their inbox and in-app.",
+    });
+  };
+
+  return (
+    <DashboardLayout>
+      <div className="flex min-h-screen flex-col bg-gradient-subtle">
+        <PageHeader
+          title="People"
+          description="Manage teammates, monitor invite status, and coordinate collaboration in one place."
+          actions={(
+            <>
+              <Button variant="outline" size="sm" onClick={handleFilter}>
+                <Filter className="mr-2 h-4 w-4" />
+                Filter
+              </Button>
+              <Button size="sm" onClick={handleInvite} className="bg-gradient-primary text-white shadow-glow">
+                <UserPlus className="mr-2 h-4 w-4" />
+                Invite teammate
+              </Button>
+            </>
+          )}
+        />
+
+        <div className="grid gap-6 p-6 lg:grid-cols-[2fr,1fr]">
+          <Card className="shadow-card">
+            <CardHeader className="border-b border-border/60 pb-4">
+              <CardTitle className="text-lg font-semibold text-foreground">Team directory</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4 pt-4">
+              {team.map((member) => (
+                <div key={member.email} className="flex flex-col gap-3 rounded-xl border border-border/60 bg-white/70 p-4 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="flex items-center gap-3">
+                    <Avatar className="h-10 w-10">
+                      <AvatarImage src={member.avatar ?? undefined} alt={member.name} />
+                      <AvatarFallback className="bg-gradient-accent text-sm font-semibold text-white">
+                        {member.initials}
+                      </AvatarFallback>
+                    </Avatar>
+                    <div>
+                      <p className="text-sm font-semibold text-foreground">{member.name}</p>
+                      <p className="text-xs text-muted-foreground">{member.title}</p>
+                      <p className="text-xs text-muted-foreground/80">{member.email}</p>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Badge variant="secondary" className="text-xs">
+                      {member.status}
+                    </Badge>
+                    <Button size="sm" variant="outline" className="gap-2" onClick={() => handleMessage(member.name)}>
+                      <Mail className="h-4 w-4" />
+                      Message
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+
+          <Card className="shadow-card">
+            <CardHeader>
+              <CardTitle className="text-lg font-semibold text-foreground">Pending invitations</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm">
+              {invites.map((invite) => (
+                <div key={invite.email} className="rounded-lg bg-muted/40 px-3 py-2">
+                  <p className="font-semibold text-foreground">{invite.email}</p>
+                  <p className="text-muted-foreground">{invite.role} · {invite.sent}</p>
+                </div>
+              ))}
+              <p className="text-xs text-muted-foreground">All invites include SSO and role-based access by default.</p>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+};
+
+export default People;

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
+
+import { DashboardLayout } from "@/components/DashboardLayout";
+import { PageHeader } from "@/components/PageHeader";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { useToast } from "@/hooks/use-toast";
+import { Search as SearchIcon, Filter } from "lucide-react";
+
+const results = [
+  { title: "Customer success playbook", context: "Task in Q4 launch", type: "Task" },
+  { title: "Implementation checklist", context: "Document in Files", type: "Document" },
+  { title: "Emma Davis", context: "Recruiter · People", type: "Person" },
+];
+
+const Search = () => {
+  const [query, setQuery] = useState("customer");
+  const location = useLocation();
+  const { toast } = useToast();
+
+  useEffect(() => {
+    const state = location.state as { query?: string } | null;
+    if (state?.query) {
+      setQuery(state.query);
+    }
+  }, [location.state]);
+
+  const handleFilter = () => {
+    toast({
+      title: "Filters",
+      description: "Apply tags, owners, or activity type to narrow results.",
+    });
+  };
+
+  const handleSearch = () => {
+    toast({
+      title: "Search submitted",
+      description: `Showing results for "${query}" across your workspace.`,
+    });
+  };
+
+  return (
+    <DashboardLayout>
+      <div className="flex min-h-screen flex-col bg-gradient-subtle">
+        <PageHeader
+          title="Search"
+          description="Find tasks, files, people, and updates across your workspace."
+          actions={(
+            <Button variant="outline" size="sm" onClick={handleFilter}>
+              <Filter className="mr-2 h-4 w-4" />
+              Filters
+            </Button>
+          )}
+        />
+
+        <div className="p-6">
+          <Card className="shadow-card">
+            <CardHeader>
+              <CardTitle className="text-lg font-semibold text-foreground">Search workspace</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex flex-col gap-3 sm:flex-row">
+                <div className="flex-1">
+                  <Input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Search..." />
+                </div>
+                <Button onClick={handleSearch} className="bg-gradient-primary text-white shadow-glow">
+                  <SearchIcon className="mr-2 h-4 w-4" />
+                  Search
+                </Button>
+              </div>
+              <div className="space-y-3">
+                {results.map((result) => (
+                  <div key={result.title} className="rounded-lg border border-border/60 bg-white/70 p-4">
+                    <p className="text-sm font-semibold text-foreground">{result.title}</p>
+                    <p className="text-xs text-muted-foreground">{result.context}</p>
+                    <p className="text-xs text-muted-foreground/70">{result.type}</p>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+};
+
+export default Search;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,0 +1,82 @@
+import { DashboardLayout } from "@/components/DashboardLayout";
+import { PageHeader } from "@/components/PageHeader";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { useToast } from "@/hooks/use-toast";
+import { Save } from "lucide-react";
+
+const Settings = () => {
+  const { toast } = useToast();
+
+  const handleSave = () => {
+    toast({
+      title: "Settings saved",
+      description: "Your preferences have been updated for this workspace.",
+    });
+  };
+
+  return (
+    <DashboardLayout>
+      <div className="flex min-h-screen flex-col bg-gradient-subtle">
+        <PageHeader
+          title="Settings"
+          description="Update workspace branding, notification preferences, and security controls."
+        />
+
+        <div className="grid gap-6 p-6 lg:grid-cols-[1.5fr,1fr]">
+          <Card className="shadow-card">
+            <CardHeader>
+              <CardTitle className="text-lg font-semibold text-foreground">Workspace preferences</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="workspace-name">Workspace name</Label>
+                <Input id="workspace-name" defaultValue="Native CRM" />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="workspace-url">Workspace URL</Label>
+                <Input id="workspace-url" defaultValue="nativecrm.app/native" />
+              </div>
+              <div className="flex items-center justify-between rounded-lg bg-muted/30 px-3 py-2">
+                <div>
+                  <p className="text-sm font-medium text-foreground">Dark mode</p>
+                  <p className="text-xs text-muted-foreground">Enable adaptive theming for all members.</p>
+                </div>
+                <Switch defaultChecked />
+              </div>
+              <div className="flex items-center justify-between rounded-lg bg-muted/30 px-3 py-2">
+                <div>
+                  <p className="text-sm font-medium text-foreground">Weekly digest</p>
+                  <p className="text-xs text-muted-foreground">Send a summary of activity every Monday.</p>
+                </div>
+                <Switch defaultChecked />
+              </div>
+            </CardContent>
+            <CardFooter className="flex justify-end">
+              <Button onClick={handleSave} className="bg-gradient-primary text-white shadow-glow">
+                <Save className="mr-2 h-4 w-4" />
+                Save changes
+              </Button>
+            </CardFooter>
+          </Card>
+
+          <Card className="shadow-card">
+            <CardHeader>
+              <CardTitle className="text-lg font-semibold text-foreground">Security</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm text-muted-foreground">
+              <p>• SSO is enabled for admins and managers.</p>
+              <p>• Two-factor authentication is required for all members.</p>
+              <p>• 3 active API tokens with least-privilege access.</p>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+};
+
+export default Settings;

--- a/src/pages/Tasks.tsx
+++ b/src/pages/Tasks.tsx
@@ -1,0 +1,154 @@
+import { type ComponentType } from "react";
+
+import { DashboardLayout } from "@/components/DashboardLayout";
+import { PageHeader } from "@/components/PageHeader";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
+import { useToast } from "@/hooks/use-toast";
+import { Plus, Filter, CheckCircle2, Clock3, AlertTriangle } from "lucide-react";
+
+const tasks = [
+  {
+    title: "Finalize onboarding playbook",
+    owner: "Sarah Johnson",
+    status: "In Progress",
+    statusColor: "bg-blue-100 text-blue-600",
+    progress: 64,
+    due: "Due today",
+  },
+  {
+    title: "Prepare Q4 client review",
+    owner: "Mike Chen",
+    status: "At Risk",
+    statusColor: "bg-amber-100 text-amber-700",
+    progress: 38,
+    due: "Due in 2 days",
+  },
+  {
+    title: "Publish operations scorecard",
+    owner: "Emma Davis",
+    status: "Completed",
+    statusColor: "bg-emerald-100 text-emerald-700",
+    progress: 100,
+    due: "Completed yesterday",
+  },
+];
+
+const statusIcons: Record<string, ComponentType<{ className?: string }>> = {
+  "In Progress": Clock3,
+  "At Risk": AlertTriangle,
+  Completed: CheckCircle2,
+};
+
+const taskHighlights = [
+  {
+    label: "Active projects",
+    value: "12",
+    trend: "+3 this week",
+  },
+  {
+    label: "Tasks completed",
+    value: "47",
+    trend: "92% on time",
+  },
+  {
+    label: "Blockers",
+    value: "2",
+    trend: "Escalated to leadership",
+  },
+];
+
+const TaskStatusIcon = ({ status }: { status: string }) => {
+  const Icon = statusIcons[status] ?? Clock3;
+  return <Icon className="h-4 w-4" />;
+};
+
+const Tasks = () => {
+  const { toast } = useToast();
+
+  const handleCreateTask = () => {
+    toast({
+      title: "Create task",
+      description: "Task composer will open in a future release.",
+    });
+  };
+
+  const handleFilter = () => {
+    toast({
+      title: "Filters",
+      description: "Use tags and owners to narrow the task list.",
+    });
+  };
+
+  return (
+    <DashboardLayout>
+      <div className="flex min-h-screen flex-col bg-gradient-subtle">
+        <PageHeader
+          title="Tasks"
+          description="Track ownership, progress, and upcoming deadlines across your active work."
+          actions={(
+            <>
+              <Button variant="outline" size="sm" onClick={handleFilter}>
+                <Filter className="mr-2 h-4 w-4" />
+                Filters
+              </Button>
+              <Button size="sm" onClick={handleCreateTask} className="bg-gradient-primary text-white shadow-glow">
+                <Plus className="mr-2 h-4 w-4" />
+                New Task
+              </Button>
+            </>
+          )}
+        />
+
+        <div className="grid gap-6 p-6 lg:grid-cols-3">
+          {taskHighlights.map((highlight) => (
+            <Card key={highlight.label} className="shadow-card">
+              <CardHeader className="pb-2">
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  {highlight.label}
+                </p>
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-semibold text-foreground">{highlight.value}</div>
+                <p className="text-sm text-muted-foreground">{highlight.trend}</p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+
+        <div className="space-y-4 p-6 pt-0">
+          <h2 className="text-lg font-semibold text-foreground">Active work</h2>
+          <div className="space-y-4">
+            {tasks.map((task) => (
+              <Card key={task.title} className="shadow-card">
+                <CardHeader className="flex flex-col gap-2 border-b border-border/60 pb-4 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <CardTitle className="text-base font-semibold text-foreground">
+                      {task.title}
+                    </CardTitle>
+                    <p className="text-sm text-muted-foreground">Owner: {task.owner}</p>
+                  </div>
+                  <Badge className={`flex items-center gap-1 px-3 py-1 text-xs font-medium ${task.statusColor}`}>
+                    <TaskStatusIcon status={task.status} />
+                    {task.status}
+                  </Badge>
+                </CardHeader>
+                <CardContent className="space-y-3 pt-4">
+                  <Progress value={task.progress} />
+                  <div className="flex items-center justify-between text-sm text-muted-foreground">
+                    <span>{task.progress}% complete</span>
+                    <span>{task.due}</span>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+};
+
+export default Tasks;


### PR DESCRIPTION
## Summary
- add full page routes for tasks, calendar, people, files, careers, settings, search, notifications, and demo views so navigation no longer returns 404s
- introduce a reusable PageHeader component and wire dashboard buttons, quick actions, and the welcome banner to navigate correctly
- enhance sidebar, Dropbox, and team widgets to surface toasts or direct links when buttons are clicked

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5278c6b188331b02b3e8692cbc3d5