### PR TITLE
Add admin access controls and user management UI

### DIFF
--- a/native.backend/Native.Api/DTOs/CreateTaskAttachmentRequest.cs
+++ b/native.backend/Native.Api/DTOs/CreateTaskAttachmentRequest.cs
@@ -5,5 +5,4 @@ namespace Native.Api.DTOs;
 public record CreateTaskAttachmentRequest(
     string FileName,
     string Url,
-    string? Provider,
-    Guid? LinkedById);
+    string? Provider);

--- a/native.backend/Native.Api/DTOs/UpdateUserRequest.cs
+++ b/native.backend/Native.Api/DTOs/UpdateUserRequest.cs
@@ -1,6 +1,11 @@
+using System;
+
 namespace Native.Api.DTOs;
 
 public record UpdateUserRequest(
     string? FullName,
     string? Role,
-    bool? TwoFactorEnabled);
+    bool? TwoFactorEnabled,
+    string? Email,
+    string? Password,
+    Guid? OrganizationId);

--- a/native.backend/Native.Api/DTOs/Validators/UpdateUserRequestValidator.cs
+++ b/native.backend/Native.Api/DTOs/Validators/UpdateUserRequestValidator.cs
@@ -8,5 +8,11 @@ public class UpdateUserRequestValidator : AbstractValidator<UpdateUserRequest>
     {
         RuleFor(x => x.FullName).MaximumLength(256);
         RuleFor(x => x.Role).MaximumLength(64);
+        RuleFor(x => x.Email)
+            .EmailAddress()
+            .When(x => !string.IsNullOrWhiteSpace(x.Email));
+        RuleFor(x => x.Password)
+            .MinimumLength(6)
+            .When(x => !string.IsNullOrEmpty(x.Password));
     }
 }

--- a/native.backend/Native.Api/Extensions/ClaimsPrincipalExtensions.cs
+++ b/native.backend/Native.Api/Extensions/ClaimsPrincipalExtensions.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Security.Claims;
+
+namespace Native.Api.Extensions;
+
+public static class ClaimsPrincipalExtensions
+{
+    public static Guid GetUserId(this ClaimsPrincipal principal)
+    {
+        var identifier = principal.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (identifier is null || !Guid.TryParse(identifier, out var userId))
+        {
+            throw new InvalidOperationException("User identifier missing from token");
+        }
+
+        return userId;
+    }
+
+    public static bool IsAdmin(this ClaimsPrincipal principal)
+        => principal.IsInRole("Admin");
+}

--- a/native.backend/Native.Core/Interfaces/ICalendarService.cs
+++ b/native.backend/Native.Core/Interfaces/ICalendarService.cs
@@ -21,20 +21,22 @@ public interface ICalendarService
         string name,
         CalendarVisibility visibility,
         IEnumerable<Guid> sharedUserIds,
+        bool isAdmin,
         CancellationToken cancellationToken = default);
 
-    Task DeleteCalendarAsync(Guid calendarId, Guid requesterId, CancellationToken cancellationToken = default);
+    Task DeleteCalendarAsync(Guid calendarId, Guid requesterId, bool isAdmin, CancellationToken cancellationToken = default);
 
     Task<IEnumerable<CalendarEvent>> GetEventsForCalendarAsync(
         Guid calendarId,
         Guid requesterId,
         DateTime? start,
         DateTime? end,
+        bool isAdmin,
         CancellationToken cancellationToken = default);
 
-    Task<CalendarEvent> UpsertEventAsync(CalendarEvent calendarEvent, Guid requesterId, CancellationToken cancellationToken = default);
+    Task<CalendarEvent> UpsertEventAsync(CalendarEvent calendarEvent, Guid requesterId, bool isAdmin, CancellationToken cancellationToken = default);
 
-    Task DeleteEventAsync(Guid calendarId, Guid eventId, Guid requesterId, CancellationToken cancellationToken = default);
+    Task DeleteEventAsync(Guid calendarId, Guid eventId, Guid requesterId, bool isAdmin, CancellationToken cancellationToken = default);
 
     Task<IEnumerable<CalendarEvent>> GetEventsForTaskAsync(Guid taskId, CancellationToken cancellationToken = default);
 }

--- a/native.backend/Native.Core/Interfaces/ITaskAttachmentService.cs
+++ b/native.backend/Native.Core/Interfaces/ITaskAttachmentService.cs
@@ -1,12 +1,14 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Native.Core.Entities;
 
 namespace Native.Core.Interfaces;
 
 public interface ITaskAttachmentService
 {
-    Task<TaskAttachment> CreateAsync(TaskAttachment attachment, CancellationToken cancellationToken = default);
+    Task<TaskAttachment> CreateAsync(TaskAttachment attachment, Guid requesterId, CancellationToken cancellationToken = default);
     Task<IEnumerable<TaskAttachment>> GetByTaskAsync(Guid taskId, CancellationToken cancellationToken = default);
-    Task DeleteAsync(Guid taskId, Guid attachmentId, CancellationToken cancellationToken = default);
+    Task DeleteAsync(Guid taskId, Guid attachmentId, Guid requesterId, bool isAdmin, CancellationToken cancellationToken = default);
 }

--- a/native.backend/Native.Core/Interfaces/ITaskService.cs
+++ b/native.backend/Native.Core/Interfaces/ITaskService.cs
@@ -23,6 +23,15 @@ public interface ITaskService
         DateTime? dueBefore = null,
         CancellationToken cancellationToken = default);
     Task<IEnumerable<TaskItem>> SearchTasksAsync(Guid orgId, string query, Guid? projectId = null, CancellationToken cancellationToken = default);
-    Task UpdateTaskStatusAsync(Guid taskId, string status, CancellationToken cancellationToken = default);
-    Task UpdateTaskDetailsAsync(Guid taskId, string? title, string? description, string? priority, DateTime? dueAt, CancellationToken cancellationToken = default);
+    Task UpdateTaskStatusAsync(Guid taskId, Guid requesterId, string status, bool isAdmin, CancellationToken cancellationToken = default);
+    Task UpdateTaskDetailsAsync(
+        Guid taskId,
+        Guid requesterId,
+        string? title,
+        string? description,
+        string? priority,
+        DateTime? dueAt,
+        bool isAdmin,
+        CancellationToken cancellationToken = default);
+    Task DeleteTaskAsync(Guid taskId, Guid requesterId, bool isAdmin, CancellationToken cancellationToken = default);
 }

--- a/native.backend/Native.Core/Services/TaskAttachmentService.cs
+++ b/native.backend/Native.Core/Services/TaskAttachmentService.cs
@@ -16,8 +16,9 @@ public class TaskAttachmentService : ITaskAttachmentService
         _repository = repository;
     }
 
-    public async Task<TaskAttachment> CreateAsync(TaskAttachment attachment, CancellationToken cancellationToken = default)
+    public async Task<TaskAttachment> CreateAsync(TaskAttachment attachment, Guid requesterId, CancellationToken cancellationToken = default)
     {
+        attachment.LinkedById = requesterId;
         var created = await _repository.AddAsync(attachment, cancellationToken);
         await _repository.SaveChangesAsync(cancellationToken);
         return created;
@@ -26,13 +27,23 @@ public class TaskAttachmentService : ITaskAttachmentService
     public Task<IEnumerable<TaskAttachment>> GetByTaskAsync(Guid taskId, CancellationToken cancellationToken = default)
         => _repository.GetByTaskAsync(taskId, cancellationToken);
 
-    public async Task DeleteAsync(Guid taskId, Guid attachmentId, CancellationToken cancellationToken = default)
+    public async Task DeleteAsync(
+        Guid taskId,
+        Guid attachmentId,
+        Guid requesterId,
+        bool isAdmin,
+        CancellationToken cancellationToken = default)
     {
         var attachment = await _repository.GetByIdAsync(attachmentId, cancellationToken)
                          ?? throw new KeyNotFoundException($"Attachment {attachmentId} not found");
         if (attachment.TaskId != taskId)
         {
             throw new InvalidOperationException("Attachment does not belong to the provided task");
+        }
+
+        if (!isAdmin && attachment.LinkedById != requesterId)
+        {
+            throw new UnauthorizedAccessException("You can only remove attachments you linked");
         }
         await _repository.RemoveAsync(attachment, cancellationToken);
         await _repository.SaveChangesAsync(cancellationToken);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,8 @@ import Register from "./pages/Register";
 import Goals from "./pages/Goals";
 import { AuthProvider } from "./context/AuthContext";
 import { RequireAuth } from "./components/RequireAuth";
+import { RequireAdmin } from "./components/RequireAdmin";
+import AdminUsers from "./pages/AdminUsers";
 
 const queryClient = new QueryClient();
 
@@ -44,6 +46,9 @@ const App = () => (
               <Route path="/notifications" element={<Notifications />} />
               <Route path="/demo" element={<Demo />} />
               <Route path="/goals" element={<Goals />} />
+              <Route element={<RequireAdmin />}>
+                <Route path="/admin/users" element={<AdminUsers />} />
+              </Route>
             </Route>
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -11,6 +11,7 @@ import {
   ChevronRight,
   Layout,
   FileText,
+  ShieldCheck,
 } from "lucide-react";
 
 import {
@@ -48,6 +49,10 @@ const resourcesNavItems = [
   { title: "Dashboards", url: "/demo", icon: Layout },
   { title: "Docs", url: "/files", icon: FileText },
   { title: "Settings", url: "/settings", icon: Settings },
+];
+
+const adminNavItems = [
+  { title: "User management", url: "/admin/users", icon: ShieldCheck },
 ];
 
 export function AppSidebar() {
@@ -199,6 +204,34 @@ export function AppSidebar() {
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>
+
+        {user?.role.toLowerCase() === "admin" && (
+          <SidebarGroup className="mt-6">
+            <SidebarGroupLabel className={collapsed ? "sr-only" : "uppercase tracking-wide text-xs text-muted-foreground"}>
+              Administration
+            </SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu className="space-y-1">
+                {adminNavItems.map((item) => (
+                  <SidebarMenuItem key={item.title}>
+                    <SidebarMenuButton asChild>
+                      <NavLink
+                        to={item.url}
+                        className={({ isActive }) => `
+                          flex items-center px-3 py-2 rounded-lg transition-all duration-200
+                          ${getNavCls({ isActive })}
+                        `}
+                      >
+                        <item.icon className="h-5 w-5 flex-shrink-0" />
+                        {!collapsed && <span className="ml-3">{item.title}</span>}
+                      </NavLink>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                ))}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        )}
       </SidebarContent>
 
       <SidebarFooter className="p-4 border-t">

--- a/src/components/RequireAdmin.tsx
+++ b/src/components/RequireAdmin.tsx
@@ -1,0 +1,21 @@
+import { Navigate, Outlet } from "react-router-dom";
+
+import { useAuth } from "@/context/AuthContext";
+
+export const RequireAdmin = () => {
+  const { user, loading } = useAuth();
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-muted/20">
+        <div className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (!user || user.role.toLowerCase() !== "admin") {
+    return <Navigate to="/" replace />;
+  }
+
+  return <Outlet />;
+};

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -226,3 +226,41 @@ export const fetchUsersLookup = (token: string) =>
     method: "GET",
     token,
   });
+
+export interface AdminUser {
+  id: string;
+  email: string;
+  fullName: string;
+  role: string;
+  organizationId?: string | null;
+  isTwoFactorEnabled: boolean;
+  createdAt: string;
+}
+
+export const fetchUsers = (token: string) =>
+  request<AdminUser[]>("/api/users", {
+    method: "GET",
+    token,
+  });
+
+export interface UpdateUserInput {
+  fullName?: string;
+  role?: string;
+  twoFactorEnabled?: boolean;
+  email?: string;
+  password?: string;
+  organizationId?: string | null;
+}
+
+export const updateUser = (token: string, userId: string, payload: UpdateUserInput) =>
+  request<AdminUser>(`/api/users/${userId}`, {
+    method: "PATCH",
+    token,
+    body: JSON.stringify(payload),
+  });
+
+export const deleteUser = (token: string, userId: string) =>
+  request<void>(`/api/users/${userId}`, {
+    method: "DELETE",
+    token,
+  });

--- a/src/pages/AdminUsers.tsx
+++ b/src/pages/AdminUsers.tsx
@@ -1,0 +1,425 @@
+import { useEffect, useMemo, useState } from "react";
+import { useForm } from "react-hook-form";
+import { format } from "date-fns";
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+
+import { DashboardLayout } from "@/components/DashboardLayout";
+import { PageHeader } from "@/components/PageHeader";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { useAuth } from "@/context/AuthContext";
+import {
+  AdminUser,
+  deleteUser,
+  fetchUsers,
+  updateUser,
+  type UpdateUserInput,
+} from "@/lib/api";
+import { useToast } from "@/hooks/use-toast";
+import { Loader2, ShieldCheck } from "lucide-react";
+
+interface UpdateUserFormValues {
+  fullName: string;
+  email: string;
+  role: string;
+  password: string;
+  organizationId: string;
+  twoFactorEnabled: boolean;
+}
+
+const defaultFormValues: UpdateUserFormValues = {
+  fullName: "",
+  email: "",
+  role: "",
+  password: "",
+  organizationId: "",
+  twoFactorEnabled: false,
+};
+
+const AdminUsers = () => {
+  const { token } = useAuth();
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const [isDialogOpen, setDialogOpen] = useState(false);
+  const [selectedUser, setSelectedUser] = useState<AdminUser | null>(null);
+  const [userToDelete, setUserToDelete] = useState<AdminUser | null>(null);
+
+  const usersQuery = useQuery({
+    queryKey: ["admin-users"],
+    queryFn: () => fetchUsers(token!),
+    enabled: Boolean(token),
+  });
+
+  const form = useForm<UpdateUserFormValues>({
+    defaultValues: defaultFormValues,
+  });
+
+  useEffect(() => {
+    if (selectedUser) {
+      form.reset({
+        fullName: selectedUser.fullName,
+        email: selectedUser.email,
+        role: selectedUser.role,
+        password: "",
+        organizationId: selectedUser.organizationId ?? "",
+        twoFactorEnabled: selectedUser.isTwoFactorEnabled,
+      });
+    }
+  }, [selectedUser, form]);
+
+  const updateMutation = useMutation({
+    mutationFn: async ({ id, values }: { id: string; values: UpdateUserInput }) => {
+      if (!token) {
+        throw new Error("Missing authentication token");
+      }
+      return updateUser(token, id, values);
+    },
+    onSuccess: (updated) => {
+      toast({
+        title: "User updated",
+        description: `${updated.fullName} has been updated successfully.`,
+      });
+      setDialogOpen(false);
+      setSelectedUser(null);
+      queryClient.invalidateQueries({ queryKey: ["admin-users"] });
+    },
+    onError: (error: unknown) => {
+      const message = error instanceof Error ? error.message : "Unable to update user";
+      toast({ title: "Update failed", description: message, variant: "destructive" });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (id: string) => {
+      if (!token) {
+        throw new Error("Missing authentication token");
+      }
+      await deleteUser(token, id);
+    },
+    onSuccess: () => {
+      toast({ title: "User deleted", description: "The account has been removed." });
+      setUserToDelete(null);
+      queryClient.invalidateQueries({ queryKey: ["admin-users"] });
+    },
+    onError: (error: unknown) => {
+      const message = error instanceof Error ? error.message : "Unable to delete user";
+      toast({ title: "Delete failed", description: message, variant: "destructive" });
+    },
+  });
+
+  const onSubmit = (values: UpdateUserFormValues) => {
+    if (!selectedUser) return;
+
+    const payload: UpdateUserInput = {
+      fullName: values.fullName.trim() || undefined,
+      email: values.email.trim() || undefined,
+      role: values.role.trim() || undefined,
+      password: values.password.trim() ? values.password : undefined,
+      organizationId: values.organizationId.trim() ? values.organizationId.trim() : undefined,
+      twoFactorEnabled: values.twoFactorEnabled,
+    };
+
+    updateMutation.mutate({ id: selectedUser.id, values: payload });
+  };
+
+  const sortedUsers = useMemo(() => {
+    if (!usersQuery.data) return [] as AdminUser[];
+    return [...usersQuery.data].sort((a, b) =>
+      new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    );
+  }, [usersQuery.data]);
+
+  return (
+    <DashboardLayout>
+      <div className="flex min-h-screen flex-col bg-gradient-subtle">
+        <PageHeader
+          title="User administration"
+          description="Review every account in the workspace, adjust credentials, and remove access when required."
+          actions={
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => usersQuery.refetch()}
+              disabled={usersQuery.isFetching}
+            >
+              Refresh
+            </Button>
+          }
+        />
+
+        <div className="p-6">
+          <Card className="shadow-card">
+            <CardHeader className="flex flex-row items-center justify-between border-b border-border/60 pb-4">
+              <div>
+                <CardTitle className="flex items-center gap-2 text-lg font-semibold text-foreground">
+                  <ShieldCheck className="h-5 w-5 text-primary" />
+                  Directory access
+                </CardTitle>
+              </div>
+            </CardHeader>
+            <CardContent className="pt-4">
+              {usersQuery.isLoading ? (
+                <div className="flex items-center justify-center py-16">
+                  <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+                </div>
+              ) : usersQuery.isError ? (
+                <p className="text-sm text-destructive">
+                  {(usersQuery.error as Error)?.message ?? "Unable to load users."}
+                </p>
+              ) : sortedUsers.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No users found.</p>
+              ) : (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Name</TableHead>
+                      <TableHead>Email</TableHead>
+                      <TableHead>Role</TableHead>
+                      <TableHead>2FA</TableHead>
+                      <TableHead>Created</TableHead>
+                      <TableHead className="text-right">Actions</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {sortedUsers.map((entry) => (
+                      <TableRow key={entry.id}>
+                        <TableCell className="font-medium">{entry.fullName}</TableCell>
+                        <TableCell className="text-muted-foreground">{entry.email}</TableCell>
+                        <TableCell>
+                          <Badge variant="secondary" className="capitalize">
+                            {entry.role}
+                          </Badge>
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant={entry.isTwoFactorEnabled ? "default" : "outline"}>
+                            {entry.isTwoFactorEnabled ? "Enabled" : "Disabled"}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="text-muted-foreground">
+                          {format(new Date(entry.createdAt), "PP")}
+                        </TableCell>
+                        <TableCell className="text-right space-x-2">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => {
+                              setSelectedUser(entry);
+                              setDialogOpen(true);
+                            }}
+                          >
+                            Edit
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="text-destructive"
+                            onClick={() => setUserToDelete(entry)}
+                          >
+                            Delete
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+
+      <Dialog
+        open={isDialogOpen}
+        onOpenChange={(open) => {
+          setDialogOpen(open);
+          if (!open) {
+            setSelectedUser(null);
+            form.reset(defaultFormValues);
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit user</DialogTitle>
+            <DialogDescription>
+              Update account credentials, role assignment, and security preferences.
+            </DialogDescription>
+          </DialogHeader>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <FormField
+                control={form.control}
+                name="fullName"
+                rules={{ required: "Name is required" }}
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Full name</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Jane Doe" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="email"
+                rules={{ required: "Email is required" }}
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Email</FormLabel>
+                    <FormControl>
+                      <Input type="email" placeholder="jane@example.com" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="role"
+                rules={{ required: "Role is required" }}
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Role</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Admin" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="organizationId"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Organization ID</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Optional" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="password"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Reset password</FormLabel>
+                    <FormControl>
+                      <Input type="password" placeholder="Leave blank to keep current" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="twoFactorEnabled"
+                render={({ field }) => (
+                  <FormItem className="flex items-center justify-between rounded-lg border border-border/70 p-3">
+                    <div>
+                      <FormLabel className="mb-1 block">Two-factor authentication</FormLabel>
+                      <p className="text-xs text-muted-foreground">
+                        Require a second factor when signing in to this account.
+                      </p>
+                    </div>
+                    <FormControl>
+                      <Switch checked={field.value} onCheckedChange={field.onChange} />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+
+              <DialogFooter>
+                <Button
+                  type="submit"
+                  className="bg-gradient-primary text-white"
+                  disabled={updateMutation.isPending}
+                >
+                  {updateMutation.isPending ? "Saving" : "Save changes"}
+                </Button>
+              </DialogFooter>
+            </form>
+          </Form>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog open={Boolean(userToDelete)} onOpenChange={(open) => !open && setUserToDelete(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete user</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently remove {userToDelete?.fullName}. Their tasks and content will no longer be accessible.
+              This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleteMutation.isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={() => {
+                if (userToDelete) {
+                  deleteMutation.mutate(userToDelete.id);
+                }
+              }}
+              disabled={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending ? "Deleting" : "Delete"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </DashboardLayout>
+  );
+};
+
+export default AdminUsers;


### PR DESCRIPTION
## Summary
- enforce admin-aware authorization and ownership checks for tasks, attachments, and calendars, including a task delete endpoint
- expand user management APIs so admins can update credentials, toggle 2FA, and remove accounts with validation
- add an admin-only user management interface, navigation guard, and supporting API clients on the frontend

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d54586cd08833187d1b3627def4985