### PR TITLE
Enable dark mode toggling

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -180,14 +180,14 @@ export function AppSidebar() {
                       title={collapsed ? item.title : undefined}
                       className={({ isActive }) =>
                         cn(
-                          "group flex items-center gap-3 transition-all duration-300",
-                          collapsed ? "justify-center" : "px-3",
+                          "group flex items-center transition-all duration-300",
+                          collapsed ? "justify-center gap-0" : "gap-3 px-3",
                           getNavCls({ isActive }),
                         )
                       }
                     >
                       <div
-                        className={`flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br ${item.gradient} text-xs font-semibold text-white`}
+                        className={`flex h-9 w-9 items-center justify-center rounded-lg bg-gradient-to-br ${item.gradient} text-xs font-semibold text-white`}
                       >
                         {item.initials}
                       </div>

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -59,7 +59,8 @@ export function AppSidebar() {
 
   const getNavCls = ({ isActive }: { isActive: boolean }) =>
     cn(
-      "group relative flex h-full w-full items-center rounded-xl border border-transparent transition-all duration-300",
+      "group relative flex w-full items-center rounded-xl border border-transparent transition-all duration-300",
+      "min-h-[3.25rem]",
       collapsed ? "justify-center p-0" : "px-3 py-2",
       isActive
         ? "bg-gradient-to-br from-primary/30 via-primary/15 to-primary/5 text-sidebar-primary shadow-[0_18px_40px_-28px_rgba(56,189,248,0.9)] border-primary/40"
@@ -145,7 +146,13 @@ export function AppSidebar() {
                         title={collapsed ? item.title : undefined}
                         className={({ isActive }) => getNavCls({ isActive })}
                       >
-                        <item.icon className={cn("h-6 w-6 flex-shrink-0", collapsed && "mx-auto")} />
+                        <item.icon
+                          className={cn(
+                            "flex-shrink-0 transition-transform",
+                            collapsed ? "h-8 w-8" : "h-6 w-6",
+                            collapsed && "mx-auto",
+                          )}
+                        />
                         {!collapsed && <span className="ml-3 flex-1">{item.title}</span>}
                       </NavLink>
                     </SidebarMenuButton>
@@ -207,7 +214,13 @@ export function AppSidebar() {
                         title={collapsed ? item.title : undefined}
                         className={({ isActive }) => getNavCls({ isActive })}
                       >
-                        <item.icon className={cn("h-6 w-6 flex-shrink-0", collapsed && "mx-auto")} />
+                        <item.icon
+                          className={cn(
+                            "flex-shrink-0 transition-transform",
+                            collapsed ? "h-8 w-8" : "h-6 w-6",
+                            collapsed && "mx-auto",
+                          )}
+                        />
                         {!collapsed && <span className="ml-3">{item.title}</span>}
                       </NavLink>
                     </SidebarMenuButton>

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -1,4 +1,4 @@
-import { NavLink, useLocation, useNavigate } from "react-router-dom";
+import { Link, NavLink, useLocation, useNavigate } from "react-router-dom";
 import {
   LayoutDashboard,
   Target,
@@ -29,6 +29,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { useAuth } from "@/context/AuthContext";
+import { cn } from "@/lib/utils";
 
 const workspaceNavItems = [
   { title: "Home", url: "/", icon: LayoutDashboard },
@@ -65,20 +66,26 @@ export function AppSidebar() {
       : "hover:bg-sidebar-accent/50 text-sidebar-foreground";
 
   return (
-    <Sidebar className={`${collapsed ? "w-16" : "w-64"} border-r shadow-card transition-all duration-300`}>
-      <SidebarHeader className="p-4 border-b">
+    <Sidebar collapsible="icon" className="border-r border-sidebar-border/60 shadow-card">
+      <SidebarHeader className="p-4 border-b border-sidebar-border/60">
         <div className="flex items-center justify-between">
-          {!collapsed && (
-            <div className="flex items-center space-x-3">
-              <div className="w-10 h-10 bg-gradient-primary rounded-xl flex items-center justify-center text-lg font-bold text-white">
-                N
-              </div>
-              <div>
+          <Link
+            to="/"
+            className={cn(
+              "group flex w-full items-center rounded-lg px-2 transition-colors hover:bg-sidebar-accent/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+              collapsed ? "justify-center" : "gap-3"
+            )}
+          >
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-primary text-lg font-bold text-white shadow-sm transition-transform group-hover:scale-105">
+              N
+            </div>
+            {!collapsed && (
+              <div className="text-left">
                 <h2 className="font-semibold text-sidebar-foreground">Native CRM</h2>
                 <p className="text-xs text-sidebar-foreground/60">Workspace</p>
               </div>
-            </div>
-          )}
+            )}
+          </Link>
           <Button
             variant="ghost"
             size="sm"
@@ -88,7 +95,7 @@ export function AppSidebar() {
             {collapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}
           </Button>
         </div>
-        
+
         {!collapsed && (
           <div className="mt-4 space-y-2">
             <Button

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -1,4 +1,4 @@
-import { Link, NavLink, useLocation, useNavigate } from "react-router-dom";
+import { Link, NavLink, useNavigate } from "react-router-dom";
 import {
   LayoutDashboard,
   Target,
@@ -53,27 +53,40 @@ const resourcesNavItems = [
 
 export function AppSidebar() {
   const { state, toggleSidebar } = useSidebar();
-  const location = useLocation();
   const navigate = useNavigate();
   const { user, logout } = useAuth();
-  const currentPath = location.pathname;
   const collapsed = state === "collapsed";
 
-  const isActive = (path: string) => currentPath === path;
   const getNavCls = ({ isActive }: { isActive: boolean }) =>
-    isActive 
-      ? "bg-sidebar-accent text-sidebar-primary font-medium shadow-sm" 
-      : "hover:bg-sidebar-accent/50 text-sidebar-foreground";
+    cn(
+      "group relative flex items-center rounded-xl border border-transparent transition-all duration-300",
+      collapsed ? "justify-center p-2" : "px-3 py-2",
+      isActive
+        ? "bg-gradient-to-br from-primary/30 via-primary/15 to-primary/5 text-sidebar-primary shadow-[0_18px_40px_-28px_rgba(56,189,248,0.9)] border-primary/40"
+        : "text-sidebar-foreground hover:text-sidebar-primary hover:bg-sidebar-accent/50",
+      collapsed && !isActive && "hover:bg-sidebar-accent/40",
+    );
 
   return (
-    <Sidebar collapsible="icon" className="border-r border-sidebar-border/60 shadow-card">
-      <SidebarHeader className="p-4 border-b border-sidebar-border/60">
+    <Sidebar
+      collapsible="icon"
+      className={cn(
+        "border-r border-sidebar-border/60 bg-sidebar/95 shadow-[0_18px_48px_-20px_rgba(15,23,42,0.9)] backdrop-blur-xl transition-[background,box-shadow,border] duration-300",
+        "data-[state=collapsed]:border-sidebar-border/30 data-[state=collapsed]:bg-sidebar/60 data-[state=collapsed]:shadow-[0_20px_60px_-32px_rgba(15,23,42,0.85)]",
+      )}
+    >
+      <SidebarHeader
+        className={cn(
+          "p-4 border-b border-sidebar-border/60 transition-all duration-300",
+          collapsed && "items-center gap-3 p-3 border-sidebar-border/30",
+        )}
+      >
         <div className="flex items-center justify-between">
           <Link
             to="/"
             className={cn(
-              "group flex w-full items-center rounded-lg px-2 transition-colors hover:bg-sidebar-accent/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
-              collapsed ? "justify-center" : "gap-3"
+              "group flex w-full items-center rounded-2xl px-2 transition-colors hover:bg-sidebar-accent/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+              collapsed ? "justify-center" : "gap-3",
             )}
           >
             <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-primary text-lg font-bold text-white shadow-sm transition-transform group-hover:scale-105">
@@ -90,7 +103,11 @@ export function AppSidebar() {
             variant="ghost"
             size="sm"
             onClick={toggleSidebar}
-            className="h-8 w-8 p-0 hover:bg-sidebar-accent"
+            className={cn(
+              "h-8 w-8 p-0 transition-colors hover:bg-sidebar-accent",
+              collapsed &&
+                "bg-sidebar/70 text-sidebar-foreground shadow-[0_12px_36px_-28px_rgba(94,234,212,0.8)] hover:bg-sidebar-accent/70",
+            )}
           >
             {collapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}
           </Button>
@@ -123,7 +140,7 @@ export function AppSidebar() {
         )}
       </SidebarHeader>
 
-      <SidebarContent className="px-2 py-4">
+      <SidebarContent className={cn("px-2 py-4 transition-all duration-300", collapsed && "px-2 py-6")}> 
         <SidebarGroup>
           <SidebarGroupLabel className={collapsed ? "sr-only" : "uppercase tracking-wide text-xs text-muted-foreground"}>
             Workspace
@@ -136,10 +153,8 @@ export function AppSidebar() {
                     <NavLink
                       to={item.url}
                       end
-                      className={({ isActive }) => `
-                        flex items-center px-3 py-2 rounded-lg transition-all duration-200
-                        ${getNavCls({ isActive })}
-                      `}
+                      title={collapsed ? item.title : undefined}
+                      className={({ isActive }) => getNavCls({ isActive })}
                     >
                       <item.icon className="h-5 w-5 flex-shrink-0" />
                       {!collapsed && <span className="ml-3 flex-1">{item.title}</span>}
@@ -162,10 +177,14 @@ export function AppSidebar() {
                   <SidebarMenuButton asChild>
                     <NavLink
                       to={item.url}
-                      className={({ isActive }) => `
-                        group flex items-center gap-3 rounded-lg px-3 py-2 transition-all duration-200
-                        ${getNavCls({ isActive })}
-                      `}
+                      title={collapsed ? item.title : undefined}
+                      className={({ isActive }) =>
+                        cn(
+                          "group flex items-center gap-3 transition-all duration-300",
+                          collapsed ? "justify-center" : "px-3",
+                          getNavCls({ isActive }),
+                        )
+                      }
                     >
                       <div
                         className={`flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br ${item.gradient} text-xs font-semibold text-white`}
@@ -192,10 +211,8 @@ export function AppSidebar() {
                   <SidebarMenuButton asChild>
                     <NavLink
                       to={item.url}
-                      className={({ isActive }) => `
-                        flex items-center px-3 py-2 rounded-lg transition-all duration-200
-                        ${getNavCls({ isActive })}
-                      `}
+                      title={collapsed ? item.title : undefined}
+                      className={({ isActive }) => getNavCls({ isActive })}
                     >
                       <item.icon className="h-5 w-5 flex-shrink-0" />
                       {!collapsed && <span className="ml-3">{item.title}</span>}
@@ -208,7 +225,12 @@ export function AppSidebar() {
         </SidebarGroup>
       </SidebarContent>
 
-      <SidebarFooter className="p-4 border-t">
+      <SidebarFooter
+        className={cn(
+          "p-4 border-t border-sidebar-border/60 transition-all duration-300",
+          collapsed && "items-center border-sidebar-border/30",
+        )}
+      >
         <div className="flex items-center space-x-3">
           <Avatar className="h-8 w-8">
             <AvatarImage src="/placeholder-avatar.jpg" alt={user?.fullName ?? "User"} />

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -78,18 +78,18 @@ export function AppSidebar() {
       <div className="relative flex h-full flex-col">
         <Button
           variant="ghost"
-          size="icon"
           aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
           onClick={toggleSidebar}
           className={cn(
-            "group absolute top-6 -right-6 z-50 flex h-11 w-11 items-center justify-center rounded-full border border-sidebar-border/50 bg-gradient-to-br from-sidebar-accent/90 via-sidebar/80 to-sidebar/70 text-sidebar-foreground shadow-[0_18px_48px_-18px_rgba(15,23,42,0.75)] backdrop-blur-xl transition-all duration-300 hover:-right-7 hover:text-sidebar-primary",
-            "after:absolute after:inset-0 after:rounded-full after:border after:border-sidebar-border/40 after:opacity-0 after:transition-opacity after:duration-300 group-hover:after:opacity-100",
+            "group absolute top-1/2 -right-16 z-50 flex h-14 w-14 -translate-y-1/2 items-center justify-center rounded-3xl border border-sidebar-border/40 bg-gradient-to-br from-sidebar-accent/95 via-sidebar/80 to-sidebar/70 text-sidebar-foreground shadow-[0_18px_48px_-18px_rgba(8,12,24,0.85)] transition-all duration-300",
+            "after:absolute after:inset-0 after:rounded-3xl after:border after:border-primary/30 after:opacity-0 after:transition-opacity after:duration-300 group-hover:after:opacity-100",
+            "hover:-right-[4.75rem] hover:text-sidebar-primary/90",
             collapsed
-              ? "-right-8 bg-sidebar-accent/80 text-sidebar-primary shadow-[0_20px_60px_-24px_rgba(56,189,248,0.65)]"
-              : "hover:bg-sidebar-accent/80 hover:shadow-[0_22px_60px_-26px_rgba(56,189,248,0.45)]",
+              ? "-right-[4.5rem] bg-primary/30 text-primary-foreground shadow-[0_24px_64px_-26px_rgba(56,189,248,0.55)]"
+              : "hover:bg-primary/20 hover:shadow-[0_26px_72px_-32px_rgba(56,189,248,0.45)]",
           )}
         >
-          {collapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}
+          {collapsed ? <ChevronRight className="h-5 w-5" /> : <ChevronLeft className="h-5 w-5" />}
         </Button>
         <SidebarHeader
           className={cn(

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -82,8 +82,11 @@ export function AppSidebar() {
           aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
           onClick={toggleSidebar}
           className={cn(
-            "group absolute top-6 -right-5 z-50 h-9 w-9 rounded-full border border-sidebar-border/70 bg-sidebar/90 text-sidebar-foreground shadow-lg backdrop-blur transition-all hover:-right-6 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
-            collapsed && "-right-7 bg-sidebar/70 text-sidebar-foreground/90",
+            "group absolute top-6 -right-6 z-50 flex h-11 w-11 items-center justify-center rounded-full border border-sidebar-border/50 bg-gradient-to-br from-sidebar-accent/90 via-sidebar/80 to-sidebar/70 text-sidebar-foreground shadow-[0_18px_48px_-18px_rgba(15,23,42,0.75)] backdrop-blur-xl transition-all duration-300 hover:-right-7 hover:text-sidebar-primary",
+            "after:absolute after:inset-0 after:rounded-full after:border after:border-sidebar-border/40 after:opacity-0 after:transition-opacity after:duration-300 group-hover:after:opacity-100",
+            collapsed
+              ? "-right-8 bg-sidebar-accent/80 text-sidebar-primary shadow-[0_20px_60px_-24px_rgba(56,189,248,0.65)]"
+              : "hover:bg-sidebar-accent/80 hover:shadow-[0_22px_60px_-26px_rgba(56,189,248,0.45)]",
           )}
         >
           {collapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -136,7 +136,7 @@ export function AppSidebar() {
               Workspace
             </SidebarGroupLabel>
             <SidebarGroupContent>
-              <SidebarMenu className={cn("space-y-1", collapsed && "space-y-0 items-center gap-3")}>
+              <SidebarMenu className={cn("space-y-1", collapsed && "space-y-0 gap-3")}>
                 {workspaceNavItems.map((item) => (
                   <SidebarMenuItem key={item.title}>
                     <SidebarMenuButton asChild>
@@ -167,7 +167,7 @@ export function AppSidebar() {
               Spaces
             </SidebarGroupLabel>
             <SidebarGroupContent>
-              <SidebarMenu className={cn("space-y-1", collapsed && "space-y-0 items-center gap-3")}>
+              <SidebarMenu className={cn("space-y-1", collapsed && "space-y-0 gap-3")}>
                 {spaceNavItems.map((item) => (
                   <SidebarMenuItem key={item.title}>
                     <SidebarMenuButton asChild>
@@ -205,7 +205,7 @@ export function AppSidebar() {
               Resources
             </SidebarGroupLabel>
             <SidebarGroupContent>
-              <SidebarMenu className={cn("space-y-1", collapsed && "space-y-0 items-center gap-3")}>
+              <SidebarMenu className={cn("space-y-1", collapsed && "space-y-0 gap-3")}>
                 {resourcesNavItems.map((item) => (
                   <SidebarMenuItem key={item.title}>
                     <SidebarMenuButton asChild>

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -59,8 +59,8 @@ export function AppSidebar() {
 
   const getNavCls = ({ isActive }: { isActive: boolean }) =>
     cn(
-      "group relative flex items-center rounded-xl border border-transparent transition-all duration-300",
-      collapsed ? "justify-center p-2" : "px-3 py-2",
+      "group relative flex h-full w-full items-center rounded-xl border border-transparent transition-all duration-300",
+      collapsed ? "justify-center p-0" : "px-3 py-2",
       isActive
         ? "bg-gradient-to-br from-primary/30 via-primary/15 to-primary/5 text-sidebar-primary shadow-[0_18px_40px_-28px_rgba(56,189,248,0.9)] border-primary/40"
         : "text-sidebar-foreground hover:text-sidebar-primary hover:bg-sidebar-accent/50",
@@ -76,21 +76,6 @@ export function AppSidebar() {
       )}
     >
       <div className="relative flex h-full flex-col">
-        <Button
-          variant="ghost"
-          aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
-          onClick={toggleSidebar}
-          className={cn(
-            "group absolute top-1/2 -right-16 z-50 flex h-14 w-14 -translate-y-1/2 items-center justify-center rounded-3xl border border-sidebar-border/40 bg-gradient-to-br from-sidebar-accent/95 via-sidebar/80 to-sidebar/70 text-sidebar-foreground shadow-[0_18px_48px_-18px_rgba(8,12,24,0.85)] transition-all duration-300",
-            "after:absolute after:inset-0 after:rounded-3xl after:border after:border-primary/30 after:opacity-0 after:transition-opacity after:duration-300 group-hover:after:opacity-100",
-            "hover:-right-[4.75rem] hover:text-sidebar-primary/90",
-            collapsed
-              ? "-right-[4.5rem] bg-primary/30 text-primary-foreground shadow-[0_24px_64px_-26px_rgba(56,189,248,0.55)]"
-              : "hover:bg-primary/20 hover:shadow-[0_26px_72px_-32px_rgba(56,189,248,0.45)]",
-          )}
-        >
-          {collapsed ? <ChevronRight className="h-5 w-5" /> : <ChevronLeft className="h-5 w-5" />}
-        </Button>
         <SidebarHeader
           className={cn(
             "p-4 border-b border-sidebar-border/60 transition-all duration-300",
@@ -144,7 +129,7 @@ export function AppSidebar() {
           )}
         </SidebarHeader>
 
-        <SidebarContent className={cn("px-3 py-4 transition-all duration-300", collapsed && "px-2 py-6")}> 
+        <SidebarContent className={cn("px-3 py-4 transition-all duration-300", collapsed && "px-2 py-6")}>
           <SidebarGroup>
             <SidebarGroupLabel className={collapsed ? "sr-only" : "uppercase tracking-wide text-xs text-muted-foreground"}>
               Workspace
@@ -160,7 +145,7 @@ export function AppSidebar() {
                         title={collapsed ? item.title : undefined}
                         className={({ isActive }) => getNavCls({ isActive })}
                       >
-                        <item.icon className={cn("h-5 w-5 flex-shrink-0", collapsed && "mx-auto")} />
+                        <item.icon className={cn("h-6 w-6 flex-shrink-0", collapsed && "mx-auto")} />
                         {!collapsed && <span className="ml-3 flex-1">{item.title}</span>}
                       </NavLink>
                     </SidebarMenuButton>
@@ -192,7 +177,7 @@ export function AppSidebar() {
                       >
                         <div
                           className={cn(
-                            "flex h-9 w-9 items-center justify-center rounded-lg bg-gradient-to-br text-xs font-semibold text-white",
+                            "flex h-11 w-11 items-center justify-center rounded-lg bg-gradient-to-br text-sm font-semibold text-white",
                             item.gradient,
                             collapsed && "mx-auto",
                           )}
@@ -222,7 +207,7 @@ export function AppSidebar() {
                         title={collapsed ? item.title : undefined}
                         className={({ isActive }) => getNavCls({ isActive })}
                       >
-                        <item.icon className={cn("h-5 w-5 flex-shrink-0", collapsed && "mx-auto")} />
+                        <item.icon className={cn("h-6 w-6 flex-shrink-0", collapsed && "mx-auto")} />
                         {!collapsed && <span className="ml-3">{item.title}</span>}
                       </NavLink>
                     </SidebarMenuButton>
@@ -231,6 +216,27 @@ export function AppSidebar() {
               </SidebarMenu>
             </SidebarGroupContent>
           </SidebarGroup>
+
+          <div className="mt-auto pt-6">
+            <Button
+              variant="ghost"
+              aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+              onClick={toggleSidebar}
+              className={cn(
+                "group flex w-full items-center justify-center gap-3 rounded-2xl border border-sidebar-border/60 bg-sidebar/70 px-3 py-3 text-sidebar-foreground transition-all duration-300 hover:border-primary/30 hover:bg-sidebar-accent/40",
+                collapsed
+                  ? "h-12 w-full justify-center border-sidebar-border/40 bg-sidebar/50"
+                  : "justify-between",
+              )}
+            >
+              {!collapsed && <span className="text-sm font-medium">Collapse menu</span>}
+              {collapsed ? (
+                <ChevronRight className="h-5 w-5 transition-transform group-hover:translate-x-0.5" />
+              ) : (
+                <ChevronLeft className="h-5 w-5 transition-transform group-hover:-translate-x-0.5" />
+              )}
+            </Button>
+          </div>
         </SidebarContent>
 
         <SidebarFooter

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -75,187 +75,193 @@ export function AppSidebar() {
         "data-[state=collapsed]:border-sidebar-border/30 data-[state=collapsed]:bg-sidebar/60 data-[state=collapsed]:shadow-[0_20px_60px_-32px_rgba(15,23,42,0.85)]",
       )}
     >
-      <SidebarHeader
-        className={cn(
-          "p-4 border-b border-sidebar-border/60 transition-all duration-300",
-          collapsed && "items-center gap-3 p-3 border-sidebar-border/30",
-        )}
-      >
-        <div className="flex items-center justify-between">
-          <Link
-            to="/"
-            className={cn(
-              "group flex w-full items-center rounded-2xl px-2 transition-colors hover:bg-sidebar-accent/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
-              collapsed ? "justify-center" : "gap-3",
-            )}
-          >
-            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-primary text-lg font-bold text-white shadow-sm transition-transform group-hover:scale-105">
-              N
+      <div className="relative flex h-full flex-col">
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+          onClick={toggleSidebar}
+          className={cn(
+            "group absolute top-6 -right-5 z-50 h-9 w-9 rounded-full border border-sidebar-border/70 bg-sidebar/90 text-sidebar-foreground shadow-lg backdrop-blur transition-all hover:-right-6 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+            collapsed && "-right-7 bg-sidebar/70 text-sidebar-foreground/90",
+          )}
+        >
+          {collapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}
+        </Button>
+        <SidebarHeader
+          className={cn(
+            "p-4 border-b border-sidebar-border/60 transition-all duration-300",
+            collapsed && "items-center gap-3 p-3 border-sidebar-border/30",
+          )}
+        >
+          <div className="flex items-center justify-between">
+            <Link
+              to="/"
+              className={cn(
+                "group flex w-full items-center rounded-2xl px-2 transition-colors hover:bg-sidebar-accent/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+                collapsed ? "justify-center" : "gap-3",
+              )}
+            >
+              <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-primary text-lg font-bold text-white shadow-sm transition-transform group-hover:scale-105">
+                N
+              </div>
+              {!collapsed && (
+                <div className="text-left">
+                  <h2 className="font-semibold text-sidebar-foreground">Native CRM</h2>
+                  <p className="text-xs text-sidebar-foreground/60">Workspace</p>
+                </div>
+              )}
+            </Link>
+          </div>
+
+          {!collapsed && (
+            <div className="mt-4 space-y-2">
+              <Button
+                className="w-full bg-gradient-primary hover:opacity-90 shadow-sm"
+                onClick={() => navigate("/tasks")}
+              >
+                <Plus className="h-4 w-4 mr-2" />
+                New task
+              </Button>
+              <div className="relative">
+                <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 transform text-muted-foreground" />
+                <input
+                  type="text"
+                  placeholder="Search..."
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      event.preventDefault();
+                      navigate("/search", { state: { query: event.currentTarget.value } });
+                    }
+                  }}
+                  className="w-full rounded-lg border border-border bg-background py-2 pl-10 pr-4 text-sm focus:outline-none focus:ring-2 focus:ring-primary/20"
+                />
+              </div>
             </div>
+          )}
+        </SidebarHeader>
+
+        <SidebarContent className={cn("px-3 py-4 transition-all duration-300", collapsed && "px-2 py-6")}> 
+          <SidebarGroup>
+            <SidebarGroupLabel className={collapsed ? "sr-only" : "uppercase tracking-wide text-xs text-muted-foreground"}>
+              Workspace
+            </SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu className={cn("space-y-1", collapsed && "space-y-0 items-center gap-3")}>
+                {workspaceNavItems.map((item) => (
+                  <SidebarMenuItem key={item.title}>
+                    <SidebarMenuButton asChild>
+                      <NavLink
+                        to={item.url}
+                        end
+                        title={collapsed ? item.title : undefined}
+                        className={({ isActive }) => getNavCls({ isActive })}
+                      >
+                        <item.icon className={cn("h-5 w-5 flex-shrink-0", collapsed && "mx-auto")} />
+                        {!collapsed && <span className="ml-3 flex-1">{item.title}</span>}
+                      </NavLink>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                ))}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+
+          <SidebarGroup className="mt-6">
+            <SidebarGroupLabel className={collapsed ? "sr-only" : "uppercase tracking-wide text-xs text-muted-foreground"}>
+              Spaces
+            </SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu className={cn("space-y-1", collapsed && "space-y-0 items-center gap-3")}>
+                {spaceNavItems.map((item) => (
+                  <SidebarMenuItem key={item.title}>
+                    <SidebarMenuButton asChild>
+                      <NavLink
+                        to={item.url}
+                        title={collapsed ? item.title : undefined}
+                        className={({ isActive }) =>
+                          cn(
+                            "group flex items-center transition-all duration-300",
+                            collapsed ? "justify-center gap-0" : "gap-3 px-3",
+                            getNavCls({ isActive }),
+                          )
+                        }
+                      >
+                        <div
+                          className={cn(
+                            "flex h-9 w-9 items-center justify-center rounded-lg bg-gradient-to-br text-xs font-semibold text-white",
+                            item.gradient,
+                            collapsed && "mx-auto",
+                          )}
+                        >
+                          {item.initials}
+                        </div>
+                        {!collapsed && <span className="flex-1">{item.title}</span>}
+                      </NavLink>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                ))}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+
+          <SidebarGroup className="mt-6">
+            <SidebarGroupLabel className={collapsed ? "sr-only" : "uppercase tracking-wide text-xs text-muted-foreground"}>
+              Resources
+            </SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu className={cn("space-y-1", collapsed && "space-y-0 items-center gap-3")}>
+                {resourcesNavItems.map((item) => (
+                  <SidebarMenuItem key={item.title}>
+                    <SidebarMenuButton asChild>
+                      <NavLink
+                        to={item.url}
+                        title={collapsed ? item.title : undefined}
+                        className={({ isActive }) => getNavCls({ isActive })}
+                      >
+                        <item.icon className={cn("h-5 w-5 flex-shrink-0", collapsed && "mx-auto")} />
+                        {!collapsed && <span className="ml-3">{item.title}</span>}
+                      </NavLink>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                ))}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        </SidebarContent>
+
+        <SidebarFooter
+          className={cn(
+            "p-4 border-t border-sidebar-border/60 transition-all duration-300",
+            collapsed && "items-center border-sidebar-border/30",
+          )}
+        >
+          <div className="flex items-center space-x-3">
+            <Avatar className="h-8 w-8">
+              <AvatarImage src="/placeholder-avatar.jpg" alt={user?.fullName ?? "User"} />
+              <AvatarFallback className="bg-gradient-accent text-white text-sm font-medium">
+                {user?.fullName
+                  ?.split(" ")
+                  .map((part) => part[0])
+                  .join("")
+                  .slice(0, 2)
+                  .toUpperCase() || "NA"}
+              </AvatarFallback>
+            </Avatar>
             {!collapsed && (
-              <div className="text-left">
-                <h2 className="font-semibold text-sidebar-foreground">Native CRM</h2>
-                <p className="text-xs text-sidebar-foreground/60">Workspace</p>
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-medium text-sidebar-foreground">{user?.fullName ?? "Guest"}</p>
+                <p className="truncate text-xs text-sidebar-foreground/60 capitalize">{user?.role ?? "Member"}</p>
               </div>
             )}
-          </Link>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={toggleSidebar}
-            className={cn(
-              "h-8 w-8 p-0 transition-colors hover:bg-sidebar-accent",
-              collapsed &&
-                "bg-sidebar/70 text-sidebar-foreground shadow-[0_12px_36px_-28px_rgba(94,234,212,0.8)] hover:bg-sidebar-accent/70",
+            {!collapsed && (
+              <Button variant="ghost" size="sm" onClick={logout} className="h-8 px-3 text-xs">
+                Sign out
+              </Button>
             )}
-          >
-            {collapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}
-          </Button>
-        </div>
-
-        {!collapsed && (
-          <div className="mt-4 space-y-2">
-            <Button
-              className="w-full bg-gradient-primary hover:opacity-90 shadow-sm"
-              onClick={() => navigate("/tasks")}
-            >
-              <Plus className="h-4 w-4 mr-2" />
-              New task
-            </Button>
-            <div className="relative">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-              <input
-                type="text"
-                placeholder="Search..."
-                onKeyDown={(event) => {
-                  if (event.key === "Enter") {
-                    event.preventDefault();
-                    navigate("/search", { state: { query: event.currentTarget.value } });
-                  }
-                }}
-                className="w-full pl-10 pr-4 py-2 bg-background border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary/20"
-              />
-            </div>
           </div>
-        )}
-      </SidebarHeader>
-
-      <SidebarContent className={cn("px-2 py-4 transition-all duration-300", collapsed && "px-2 py-6")}> 
-        <SidebarGroup>
-          <SidebarGroupLabel className={collapsed ? "sr-only" : "uppercase tracking-wide text-xs text-muted-foreground"}>
-            Workspace
-          </SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu className="space-y-1">
-              {workspaceNavItems.map((item) => (
-                <SidebarMenuItem key={item.title}>
-                  <SidebarMenuButton asChild>
-                    <NavLink
-                      to={item.url}
-                      end
-                      title={collapsed ? item.title : undefined}
-                      className={({ isActive }) => getNavCls({ isActive })}
-                    >
-                      <item.icon className="h-5 w-5 flex-shrink-0" />
-                      {!collapsed && <span className="ml-3 flex-1">{item.title}</span>}
-                    </NavLink>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              ))}
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-
-        <SidebarGroup className="mt-6">
-          <SidebarGroupLabel className={collapsed ? "sr-only" : "uppercase tracking-wide text-xs text-muted-foreground"}>
-            Spaces
-          </SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu className="space-y-1">
-              {spaceNavItems.map((item) => (
-                <SidebarMenuItem key={item.title}>
-                  <SidebarMenuButton asChild>
-                    <NavLink
-                      to={item.url}
-                      title={collapsed ? item.title : undefined}
-                      className={({ isActive }) =>
-                        cn(
-                          "group flex items-center transition-all duration-300",
-                          collapsed ? "justify-center gap-0" : "gap-3 px-3",
-                          getNavCls({ isActive }),
-                        )
-                      }
-                    >
-                      <div
-                        className={`flex h-9 w-9 items-center justify-center rounded-lg bg-gradient-to-br ${item.gradient} text-xs font-semibold text-white`}
-                      >
-                        {item.initials}
-                      </div>
-                      {!collapsed && <span className="flex-1">{item.title}</span>}
-                    </NavLink>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              ))}
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-
-        <SidebarGroup className="mt-6">
-          <SidebarGroupLabel className={collapsed ? "sr-only" : "uppercase tracking-wide text-xs text-muted-foreground"}>
-            Resources
-          </SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu className="space-y-1">
-              {resourcesNavItems.map((item) => (
-                <SidebarMenuItem key={item.title}>
-                  <SidebarMenuButton asChild>
-                    <NavLink
-                      to={item.url}
-                      title={collapsed ? item.title : undefined}
-                      className={({ isActive }) => getNavCls({ isActive })}
-                    >
-                      <item.icon className="h-5 w-5 flex-shrink-0" />
-                      {!collapsed && <span className="ml-3">{item.title}</span>}
-                    </NavLink>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              ))}
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-      </SidebarContent>
-
-      <SidebarFooter
-        className={cn(
-          "p-4 border-t border-sidebar-border/60 transition-all duration-300",
-          collapsed && "items-center border-sidebar-border/30",
-        )}
-      >
-        <div className="flex items-center space-x-3">
-          <Avatar className="h-8 w-8">
-            <AvatarImage src="/placeholder-avatar.jpg" alt={user?.fullName ?? "User"} />
-            <AvatarFallback className="bg-gradient-accent text-white text-sm font-medium">
-              {user?.fullName
-                ?.split(" ")
-                .map((part) => part[0])
-                .join("")
-                .slice(0, 2)
-                .toUpperCase() || "NA"}
-            </AvatarFallback>
-          </Avatar>
-          {!collapsed && (
-            <div className="flex-1 min-w-0">
-              <p className="text-sm font-medium text-sidebar-foreground truncate">{user?.fullName ?? "Guest"}</p>
-              <p className="text-xs text-sidebar-foreground/60 truncate capitalize">{user?.role ?? "Member"}</p>
-            </div>
-          )}
-          {!collapsed && (
-            <Button variant="ghost" size="sm" onClick={logout} className="h-8 px-3 text-xs">
-              Sign out
-            </Button>
-          )}
-        </div>
-      </SidebarFooter>
+        </SidebarFooter>
+      </div>
     </Sidebar>
   );
 }

--- a/src/components/DashboardLayout.tsx
+++ b/src/components/DashboardLayout.tsx
@@ -1,5 +1,7 @@
 import { ReactNode } from "react";
-import { SidebarProvider } from "@/components/ui/sidebar";
+import { Link } from "react-router-dom";
+
+import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/AppSidebar";
 
 interface DashboardLayoutProps {
@@ -12,6 +14,12 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
       <div className="min-h-screen flex w-full bg-background">
         <AppSidebar />
         <main className="flex-1 overflow-auto">
+          <div className="md:hidden sticky top-0 z-30 flex items-center gap-3 border-b border-border/60 bg-background/95 px-4 py-3 backdrop-blur-sm supports-[backdrop-filter]:bg-background/85">
+            <SidebarTrigger className="h-9 w-9 rounded-lg border border-border/60 bg-card/80 text-foreground hover:bg-card" />
+            <Link to="/" className="text-sm font-semibold text-foreground">
+              Native CRM
+            </Link>
+          </div>
           {children}
         </main>
       </div>

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -8,7 +8,7 @@ interface PageHeaderProps {
 
 export function PageHeader({ title, description, actions }: PageHeaderProps) {
   return (
-    <div className="flex flex-col gap-4 border-b border-border/50 bg-white/70 p-6 backdrop-blur-sm sm:flex-row sm:items-center sm:justify-between">
+    <div className="flex flex-col gap-4 border-b border-border/60 bg-card/80 p-6 backdrop-blur supports-[backdrop-filter]:bg-card/70 sm:flex-row sm:items-center sm:justify-between">
       <div className="space-y-1">
         <h1 className="text-2xl font-semibold text-foreground">{title}</h1>
         <p className="text-muted-foreground max-w-2xl text-sm sm:text-base">{description}</p>

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,0 +1,6 @@
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import type { ThemeProviderProps } from "next-themes/dist/types";
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -14,9 +14,9 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 
 const SIDEBAR_COOKIE_NAME = "sidebar:state";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
-const SIDEBAR_WIDTH = "16rem";
-const SIDEBAR_WIDTH_MOBILE = "18rem";
-const SIDEBAR_WIDTH_ICON = "3rem";
+const SIDEBAR_WIDTH = "18rem";
+const SIDEBAR_WIDTH_MOBILE = "19rem";
+const SIDEBAR_WIDTH_ICON = "4rem";
 const SIDEBAR_KEYBOARD_SHORTCUT = "b";
 
 function readSidebarOpen(defaultOpen: boolean) {
@@ -435,7 +435,7 @@ const SidebarMenuItem = React.forwardRef<HTMLLIElement, React.ComponentProps<"li
 SidebarMenuItem.displayName = "SidebarMenuItem";
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:!h-12 group-data-[collapsible=icon]:!w-full group-data-[collapsible=icon]:!px-0 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:gap-0 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
   {
     variants: {
       variant: {

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -14,9 +14,9 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 
 const SIDEBAR_COOKIE_NAME = "sidebar:state";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
-const SIDEBAR_WIDTH = "18rem";
-const SIDEBAR_WIDTH_MOBILE = "19rem";
-const SIDEBAR_WIDTH_ICON = "4rem";
+const SIDEBAR_WIDTH = "15.5rem";
+const SIDEBAR_WIDTH_MOBILE = "18rem";
+const SIDEBAR_WIDTH_ICON = "5rem";
 const SIDEBAR_KEYBOARD_SHORTCUT = "b";
 
 function readSidebarOpen(defaultOpen: boolean) {

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -19,6 +19,27 @@ const SIDEBAR_WIDTH_MOBILE = "18rem";
 const SIDEBAR_WIDTH_ICON = "3rem";
 const SIDEBAR_KEYBOARD_SHORTCUT = "b";
 
+function readSidebarOpen(defaultOpen: boolean) {
+  if (typeof document === "undefined") {
+    return defaultOpen;
+  }
+
+  const cookie = document.cookie
+    .split("; ")
+    .find((item) => item.startsWith(`${SIDEBAR_COOKIE_NAME}=`))
+    ?.split("=")[1];
+
+  if (cookie === "true") {
+    return true;
+  }
+
+  if (cookie === "false") {
+    return false;
+  }
+
+  return defaultOpen;
+}
+
 type SidebarContext = {
   state: "expanded" | "collapsed";
   open: boolean;
@@ -53,7 +74,7 @@ const SidebarProvider = React.forwardRef<
 
   // This is the internal state of the sidebar.
   // We use openProp and setOpenProp for control from outside the component.
-  const [_open, _setOpen] = React.useState(defaultOpen);
+  const [_open, _setOpen] = React.useState(() => readSidebarOpen(defaultOpen));
   const open = openProp ?? _open;
   const setOpen = React.useCallback(
     (value: boolean | ((value: boolean) => boolean)) => {
@@ -65,7 +86,9 @@ const SidebarProvider = React.forwardRef<
       }
 
       // This sets the cookie to keep the sidebar state.
-      document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+      if (typeof document !== "undefined") {
+        document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+      }
     },
     [setOpenProp, open],
   );

--- a/src/index.css
+++ b/src/index.css
@@ -89,6 +89,16 @@
     --input: 215 25% 15%;
     --ring: 220 90% 56%;
 
+    /* Professional gradients */
+    --gradient-primary: linear-gradient(135deg, hsl(220 90% 56%), hsl(260 85% 65%));
+    --gradient-subtle: linear-gradient(135deg, hsl(215 30% 14%), hsl(215 30% 8%));
+    --gradient-accent: linear-gradient(135deg, hsl(260 70% 50%), hsl(280 75% 60%));
+
+    /* Shadows */
+    --shadow-card: 0 4px 14px hsl(220 40% 4% / 0.45);
+    --shadow-elevated: 0 16px 48px hsl(220 40% 4% / 0.55);
+    --shadow-glow: 0 0 24px hsl(220 90% 56% / 0.35);
+
     --sidebar-background: 215 30% 6%;
     --sidebar-foreground: 0 0% 90%;
     --sidebar-primary: 220 90% 56%;

--- a/src/index.css
+++ b/src/index.css
@@ -61,52 +61,52 @@
   }
 
   .dark {
-    --background: 215 30% 8%;
-    --foreground: 0 0% 98%;
+    --background: 220 28% 8%;
+    --foreground: 210 20% 92%;
 
-    --card: 215 30% 10%;
-    --card-foreground: 0 0% 98%;
+    --card: 220 28% 12%;
+    --card-foreground: 210 20% 92%;
 
-    --popover: 215 30% 10%;
-    --popover-foreground: 0 0% 98%;
+    --popover: 220 28% 12%;
+    --popover-foreground: 210 20% 92%;
 
-    --primary: 220 90% 56%;
+    --primary: 222 55% 52%;
     --primary-foreground: 0 0% 100%;
 
-    --secondary: 215 25% 15%;
-    --secondary-foreground: 0 0% 98%;
+    --secondary: 220 20% 18%;
+    --secondary-foreground: 210 15% 80%;
 
-    --muted: 215 25% 15%;
+    --muted: 220 18% 22%;
     --muted-foreground: 215 15% 65%;
 
-    --accent: 260 85% 65%;
+    --accent: 262 45% 58%;
     --accent-foreground: 0 0% 100%;
 
-    --destructive: 0 75% 60%;
+    --destructive: 0 70% 56%;
     --destructive-foreground: 0 0% 100%;
 
-    --border: 215 25% 20%;
-    --input: 215 25% 15%;
-    --ring: 220 90% 56%;
+    --border: 220 20% 22%;
+    --input: 220 20% 20%;
+    --ring: 222 55% 52%;
 
     /* Professional gradients */
-    --gradient-primary: linear-gradient(135deg, hsl(220 90% 56%), hsl(260 85% 65%));
-    --gradient-subtle: linear-gradient(135deg, hsl(215 30% 14%), hsl(215 30% 8%));
-    --gradient-accent: linear-gradient(135deg, hsl(260 70% 50%), hsl(280 75% 60%));
+    --gradient-primary: linear-gradient(135deg, hsl(222 55% 52%), hsl(262 45% 58%));
+    --gradient-subtle: linear-gradient(135deg, hsl(220 24% 16%), hsl(220 28% 8%));
+    --gradient-accent: linear-gradient(135deg, hsl(262 45% 58%), hsl(280 45% 60%));
 
     /* Shadows */
-    --shadow-card: 0 4px 14px hsl(220 40% 4% / 0.45);
-    --shadow-elevated: 0 16px 48px hsl(220 40% 4% / 0.55);
-    --shadow-glow: 0 0 24px hsl(220 90% 56% / 0.35);
+    --shadow-card: 0 4px 18px hsl(220 45% 4% / 0.35);
+    --shadow-elevated: 0 18px 52px hsl(220 45% 4% / 0.45);
+    --shadow-glow: 0 0 20px hsl(222 55% 52% / 0.25);
 
-    --sidebar-background: 215 30% 6%;
-    --sidebar-foreground: 0 0% 90%;
-    --sidebar-primary: 220 90% 56%;
+    --sidebar-background: 220 30% 7%;
+    --sidebar-foreground: 210 20% 88%;
+    --sidebar-primary: 222 55% 52%;
     --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 215 25% 12%;
-    --sidebar-accent-foreground: 0 0% 90%;
-    --sidebar-border: 215 25% 15%;
-    --sidebar-ring: 220 90% 56%;
+    --sidebar-accent: 220 20% 16%;
+    --sidebar-accent-foreground: 210 20% 88%;
+    --sidebar-border: 220 20% 20%;
+    --sidebar-ring: 222 55% 52%;
   }
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,10 @@
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
+import { ThemeProvider } from "./components/ThemeProvider";
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById("root")!).render(
+  <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+    <App />
+  </ThemeProvider>,
+);

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -218,7 +218,7 @@ const Calendar = () => {
   return (
     <DashboardLayout>
       <div className="flex min-h-screen flex-col bg-gradient-subtle">
-        <div className="border-b border-border/40 bg-white/80 backdrop-blur-sm">
+        <div className="border-b border-border/60 bg-card/80 backdrop-blur supports-[backdrop-filter]:bg-card/70">
           <div className="flex flex-col gap-4 px-6 py-5 lg:flex-row lg:items-center lg:justify-between">
             <div>
               <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-primary">
@@ -521,7 +521,7 @@ const Calendar = () => {
                     const key = format(day, "yyyy-MM-dd");
                     const events = groupedEvents.get(key) ?? [];
                     return (
-                      <div key={key} className="rounded-xl border border-border/60 bg-white/70 p-3 shadow-sm">
+                      <div key={key} className="rounded-xl border border-border/60 bg-card/80 p-3 shadow-sm">
                         <div className="flex items-center justify-between text-xs font-medium text-muted-foreground">
                           <span className="uppercase">{format(day, "EEE")}</span>
                           <Badge variant={isToday(day) ? "default" : "outline"} className="rounded-full px-2 py-0 text-[10px]">
@@ -537,7 +537,7 @@ const Calendar = () => {
                               const end = format(parseISO(event.end), "p");
                               const hasTask = Boolean(event.taskId);
                               return (
-                                <div key={event.id} className="space-y-1 rounded-lg border border-border/50 bg-gradient-to-br from-primary/10 via-white to-white p-3 text-xs">
+                                  <div key={event.id} className="space-y-1 rounded-lg border border-border/50 bg-gradient-to-br from-primary/25 via-primary/15 to-primary/5 p-3 text-xs">
                                   <div className="flex items-center justify-between gap-2">
                                     <p className="font-semibold text-foreground line-clamp-2">{event.title}</p>
                                     {hasTask && <Badge variant="outline">Task</Badge>}
@@ -564,7 +564,7 @@ const Calendar = () => {
                 <CardContent className="space-y-3 text-sm text-muted-foreground">
                   {upcomingTasksWithoutEvents.length === 0 && <p>All tasks are already scheduled on your calendars.</p>}
                   {upcomingTasksWithoutEvents.map((task) => (
-                    <div key={task.id} className="rounded-lg border border-border/40 bg-white/70 p-3 shadow-sm">
+                    <div key={task.id} className="rounded-lg border border-border/40 bg-card/80 p-3 shadow-sm">
                       <p className="font-medium text-foreground">{task.title}</p>
                       <div className="mt-1 flex items-center justify-between text-xs text-muted-foreground">
                         <span>{task.status}</span>
@@ -581,7 +581,7 @@ const Calendar = () => {
                 </CardHeader>
                 <CardContent className="space-y-3 text-sm text-muted-foreground">
                   {calendarsQuery.data?.map((calendar) => (
-                    <div key={calendar.id} className="flex items-center justify-between rounded-lg border border-border/50 bg-white/80 px-3 py-2">
+                    <div key={calendar.id} className="flex items-center justify-between rounded-lg border border-border/50 bg-card/80 px-3 py-2">
                       <div>
                         <p className="font-medium text-foreground">{calendar.name}</p>
                         <p className="text-xs text-muted-foreground">{calendar.visibility} • {calendar.sharedUserIds.length} collaborators</p>

--- a/src/pages/Careers.tsx
+++ b/src/pages/Careers.tsx
@@ -77,7 +77,7 @@ const Careers = () => {
             </CardHeader>
             <CardContent className="space-y-4 pt-4">
               {openings.map((opening) => (
-                <div key={opening.title} className="rounded-xl border border-border/60 bg-white/70 p-4 shadow-card/30">
+                <div key={opening.title} className="rounded-xl border border-border/60 bg-card/80 p-4 shadow-card/30">
                   <div className="flex items-start justify-between">
                     <div>
                       <p className="text-sm font-semibold text-foreground">{opening.title}</p>

--- a/src/pages/Files.tsx
+++ b/src/pages/Files.tsx
@@ -100,7 +100,7 @@ const Files = () => {
               {folders.map((folder) => (
                 <div
                   key={folder.path}
-                  className={`flex items-start justify-between rounded-xl border border-border/60 bg-white/70 p-4 shadow-card/30 transition-all ${highlightedFolder === folder.name ? "ring-2 ring-accent/60" : ""}`}
+                  className={`flex items-start justify-between rounded-xl border border-border/60 bg-card/80 p-4 shadow-card/30 transition-all ${highlightedFolder === folder.name ? "ring-2 ring-accent/60" : ""}`}
                 >
                   <div className="flex items-start gap-3">
                     <div className="mt-1 flex h-9 w-9 items-center justify-center rounded-lg bg-gradient-accent text-white">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -20,7 +20,7 @@ const Index = () => {
     <DashboardLayout>
       <div className="min-h-screen bg-gradient-subtle">
         {/* Header */}
-        <header className="bg-white/80 backdrop-blur-sm border-b border-border/50 sticky top-0 z-10">
+        <header className="sticky top-0 z-10 border-b border-border/60 bg-card/80 backdrop-blur supports-[backdrop-filter]:bg-card/70">
           <div className="px-6 py-4">
             <div className="flex items-center justify-between">
               <div>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -42,7 +42,7 @@ const Login = () => {
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
-      <Card className="w-full max-w-md border-0 bg-white/95 shadow-2xl">
+      <Card className="w-full max-w-md border-0 bg-card/95 shadow-2xl">
         <CardHeader className="space-y-2 text-center">
           <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-primary text-white text-lg font-bold">
             N

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -9,7 +9,7 @@ const NotFound = () => {
   }, [location.pathname]);
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-100">
+    <div className="flex min-h-screen items-center justify-center bg-background">
       <div className="text-center">
         <h1 className="mb-4 text-4xl font-bold">404</h1>
         <p className="mb-4 text-xl text-gray-600">Oops! Page not found</p>

--- a/src/pages/Notifications.tsx
+++ b/src/pages/Notifications.tsx
@@ -56,7 +56,7 @@ const Notifications = () => {
             </CardHeader>
             <CardContent className="space-y-3">
               {updates.map((update) => (
-                <div key={update.title} className="flex flex-col gap-1 rounded-lg border border-border/60 bg-white/70 p-4 sm:flex-row sm:items-center sm:justify-between">
+                <div key={update.title} className="flex flex-col gap-1 rounded-lg border border-border/60 bg-card/80 p-4 sm:flex-row sm:items-center sm:justify-between">
                   <div>
                     <p className="text-sm font-semibold text-foreground">{update.title}</p>
                     <p className="text-xs text-muted-foreground">{update.time}</p>

--- a/src/pages/People.tsx
+++ b/src/pages/People.tsx
@@ -98,7 +98,7 @@ const People = () => {
             </CardHeader>
             <CardContent className="space-y-4 pt-4">
               {team.map((member) => (
-                <div key={member.email} className="flex flex-col gap-3 rounded-xl border border-border/60 bg-white/70 p-4 sm:flex-row sm:items-center sm:justify-between">
+                <div key={member.email} className="flex flex-col gap-3 rounded-xl border border-border/60 bg-card/80 p-4 sm:flex-row sm:items-center sm:justify-between">
                   <div className="flex items-center gap-3">
                     <Avatar className="h-10 w-10">
                       <AvatarImage src={member.avatar ?? undefined} alt={member.name} />

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -54,7 +54,7 @@ const Register = () => {
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-purple-900 via-violet-800 to-indigo-900 p-6">
-      <Card className="w-full max-w-xl border-0 bg-white/95 shadow-2xl">
+      <Card className="w-full max-w-xl border-0 bg-card/95 shadow-2xl">
         <CardHeader className="space-y-2 text-center">
           <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-primary text-white text-lg font-bold">
             N

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -72,7 +72,7 @@ const Search = () => {
               </div>
               <div className="space-y-3">
                 {results.map((result) => (
-                  <div key={result.title} className="rounded-lg border border-border/60 bg-white/70 p-4">
+                  <div key={result.title} className="rounded-lg border border-border/60 bg-card/80 p-4">
                     <p className="text-sm font-semibold text-foreground">{result.title}</p>
                     <p className="text-xs text-muted-foreground">{result.context}</p>
                     <p className="text-xs text-muted-foreground/70">{result.type}</p>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { DashboardLayout } from "@/components/DashboardLayout";
 import { PageHeader } from "@/components/PageHeader";
 import { Button } from "@/components/ui/button";
@@ -7,9 +8,22 @@ import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { useToast } from "@/hooks/use-toast";
 import { Save } from "lucide-react";
+import { useTheme } from "next-themes";
 
 const Settings = () => {
   const { toast } = useToast();
+  const { resolvedTheme, setTheme } = useTheme();
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  const isDarkMode = isMounted && resolvedTheme === "dark";
+
+  const handleThemeToggle = (checked: boolean) => {
+    setTheme(checked ? "dark" : "light");
+  };
 
   const handleSave = () => {
     toast({
@@ -45,7 +59,7 @@ const Settings = () => {
                   <p className="text-sm font-medium text-foreground">Dark mode</p>
                   <p className="text-xs text-muted-foreground">Enable adaptive theming for all members.</p>
                 </div>
-                <Switch defaultChecked />
+                <Switch checked={isDarkMode} onCheckedChange={handleThemeToggle} disabled={!isMounted} />
               </div>
               <div className="flex items-center justify-between rounded-lg bg-muted/30 px-3 py-2">
                 <div>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -37,11 +37,11 @@ const Settings = () => {
       <div className="flex min-h-screen flex-col bg-gradient-subtle">
         <PageHeader
           title="Settings"
-          description="Update workspace branding, notification preferences, and security controls."
+          description="Update workspace branding and notification preferences for your team."
         />
 
-        <div className="grid gap-6 p-6 lg:grid-cols-[1.5fr,1fr]">
-          <Card className="shadow-card">
+        <div className="p-6">
+          <Card className="mx-auto w-full max-w-3xl shadow-card">
             <CardHeader>
               <CardTitle className="text-lg font-semibold text-foreground">Workspace preferences</CardTitle>
             </CardHeader>
@@ -54,14 +54,14 @@ const Settings = () => {
                 <Label htmlFor="workspace-url">Workspace URL</Label>
                 <Input id="workspace-url" defaultValue="nativecrm.app/native" />
               </div>
-              <div className="flex items-center justify-between rounded-lg bg-muted/30 px-3 py-2">
+              <div className="flex items-center justify-between rounded-lg bg-muted/40 px-3 py-2">
                 <div>
                   <p className="text-sm font-medium text-foreground">Dark mode</p>
                   <p className="text-xs text-muted-foreground">Enable adaptive theming for all members.</p>
                 </div>
                 <Switch checked={isDarkMode} onCheckedChange={handleThemeToggle} disabled={!isMounted} />
               </div>
-              <div className="flex items-center justify-between rounded-lg bg-muted/30 px-3 py-2">
+              <div className="flex items-center justify-between rounded-lg bg-muted/40 px-3 py-2">
                 <div>
                   <p className="text-sm font-medium text-foreground">Weekly digest</p>
                   <p className="text-xs text-muted-foreground">Send a summary of activity every Monday.</p>
@@ -75,17 +75,6 @@ const Settings = () => {
                 Save changes
               </Button>
             </CardFooter>
-          </Card>
-
-          <Card className="shadow-card">
-            <CardHeader>
-              <CardTitle className="text-lg font-semibold text-foreground">Security</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-3 text-sm text-muted-foreground">
-              <p>• SSO is enabled for admins and managers.</p>
-              <p>• Two-factor authentication is required for all members.</p>
-              <p>• 3 active API tokens with least-privilege access.</p>
-            </CardContent>
           </Card>
         </div>
       </div>

--- a/src/pages/Tasks.tsx
+++ b/src/pages/Tasks.tsx
@@ -19,10 +19,10 @@ import { useAuth } from "@/context/AuthContext";
 import { createTask, fetchMyTasks, type TaskInput, type TaskItem } from "@/lib/api";
 
 const statusColors: Record<string, string> = {
-  Todo: "bg-slate-100 text-slate-700",
-  "In Progress": "bg-blue-100 text-blue-700",
-  Review: "bg-amber-100 text-amber-700",
-  Done: "bg-emerald-100 text-emerald-700",
+  Todo: "border border-border/70 bg-muted/40 text-muted-foreground",
+  "In Progress": "border border-primary/40 bg-primary/15 text-primary",
+  Review: "border border-amber-500/40 bg-amber-500/15 text-amber-300",
+  Done: "border border-emerald-500/40 bg-emerald-500/15 text-emerald-300",
 };
 
 const priorities: { label: string; value: TaskInput["priority"] }[] = [
@@ -113,7 +113,7 @@ const Tasks = () => {
   return (
     <DashboardLayout>
       <div className="flex min-h-screen flex-col bg-gradient-subtle">
-        <div className="border-b border-border/40 bg-white/80 backdrop-blur-sm">
+        <div className="border-b border-border/60 bg-card/80 backdrop-blur supports-[backdrop-filter]:bg-card/70">
           <div className="flex flex-col gap-4 px-6 py-5 md:flex-row md:items-center md:justify-between">
             <div>
               <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-primary">
@@ -309,7 +309,7 @@ const Tasks = () => {
             )}
             {orderedTasks.map((task) => {
               const dueDate = task.dueAt ? format(parseISO(task.dueAt), "MMM d") : "No due date";
-              const statusBadge = statusColors[task.status] ?? "bg-slate-100 text-slate-700";
+              const statusBadge = statusColors[task.status] ?? "border border-border/70 bg-muted/40 text-muted-foreground";
               const completion = task.status === "Done" ? 100 : task.status === "Review" ? 75 : task.status === "In Progress" ? 50 : 15;
               return (
                 <Card key={task.id} className="shadow-card">


### PR DESCRIPTION
## Summary
- add a reusable ThemeProvider wrapper around next-themes so the app can toggle the Tailwind dark class
- wrap the React tree with the ThemeProvider to activate class-based theming and preserve transitions
- wire the Settings dark mode switch to the theme provider with a mounted guard so users can actually toggle light and dark

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d55098d61c83318cdf235fad1e22ca