### PR TITLE
Adjust collapsed sidebar toggle button spacing

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -232,7 +232,12 @@ export function AppSidebar() {
             </SidebarGroupContent>
           </SidebarGroup>
 
-          <div className="mt-auto pt-6">
+          <div
+            className={cn(
+              "mt-auto pt-6",
+              collapsed && "pb-10",
+            )}
+          >
             <Button
               variant="ghost"
               aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}


### PR DESCRIPTION
## Summary
- add conditional padding under the sidebar toggle button to keep it visible when collapsed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df93f44eb08331b1c14f768d86d3fb