### PR TITLE
Fix collapsed sidebar scroll behavior

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -354,7 +354,8 @@ const SidebarContent = React.forwardRef<HTMLDivElement, React.ComponentProps<"di
       ref={ref}
       data-sidebar="content"
       className={cn(
-        "flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        "flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto overflow-x-hidden",
+        "group-data-[collapsible=icon]:overflow-y-auto group-data-[collapsible=icon]:overflow-x-hidden",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
- update sidebar content container to keep vertical scrolling enabled when collapsed
- ensure horizontal overflow stays hidden to prevent icon layout shift

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df96cbe0d88331bfa84c92e59d3749