### PR TITLE
Add admin activity monitoring panel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,8 +18,10 @@ import Login from "./pages/Login";
 import Register from "./pages/Register";
 import Goals from "./pages/Goals";
 import TimeOff from "./pages/TimeOff";
+import AdminActivity from "./pages/AdminActivity";
 import { AuthProvider } from "./context/AuthContext";
 import { RequireAuth } from "./components/RequireAuth";
+import { RequireAdmin } from "./components/RequireAdmin";
 
 const queryClient = new QueryClient();
 
@@ -46,6 +48,9 @@ const App = () => (
               <Route path="/dashboards" element={<Dashboards />} />
               <Route path="/goals" element={<Goals />} />
               <Route path="/time-off" element={<TimeOff />} />
+              <Route element={<RequireAdmin />}>
+                <Route path="/admin/activity" element={<AdminActivity />} />
+              </Route>
             </Route>
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />

--- a/src/components/RequireAdmin.tsx
+++ b/src/components/RequireAdmin.tsx
@@ -1,0 +1,22 @@
+import { Navigate, Outlet, useLocation } from "react-router-dom";
+
+import { useAuth } from "@/context/AuthContext";
+
+export const RequireAdmin = () => {
+  const { user, loading } = useAuth();
+  const location = useLocation();
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-muted/20">
+        <div className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (user?.role?.toLowerCase() !== "admin") {
+    return <Navigate to="/settings" state={{ from: location }} replace />;
+  }
+
+  return <Outlet />;
+};

--- a/src/data/activityTimeline.ts
+++ b/src/data/activityTimeline.ts
@@ -1,0 +1,148 @@
+export type ActivityAudience = "all" | "admin";
+
+export interface ActivityEntry {
+  id: string;
+  user: {
+    name: string;
+    initials: string;
+    avatar: string | null;
+    role: string;
+  };
+  action: string;
+  target: string;
+  context: string;
+  time: string;
+  type: string;
+  details: string;
+  audience?: ActivityAudience;
+}
+
+export interface ActivitySection {
+  id: string;
+  label: string;
+  entries: ActivityEntry[];
+}
+
+export const activityTimeline: ActivitySection[] = [
+  {
+    id: "today",
+    label: "Today",
+    entries: [
+      {
+        id: "activity-1",
+        user: { name: "Sarah Johnson", initials: "SJ", avatar: null, role: "Product Marketing" },
+        action: "created task",
+        target: "Launch announcement brief",
+        context: "Go-to-market plan",
+        time: "12 minutes ago",
+        type: "Task",
+        details: "Set due date for Oct 12 and assigned to launch squad",
+      },
+      {
+        id: "activity-2",
+        user: { name: "Mike Chen", initials: "MC", avatar: null, role: "Client Success" },
+        action: "uploaded file",
+        target: "Q4 client review deck.pdf",
+        context: "Client Success > Q4 Reviews",
+        time: "27 minutes ago",
+        type: "File",
+        details: "Version 3.1 added with updated revenue forecasts",
+      },
+      {
+        id: "activity-3",
+        user: { name: "Emma Davis", initials: "ED", avatar: null, role: "Talent" },
+        action: "created candidate profile",
+        target: "Alex Morgan",
+        context: "Marketing Manager Hiring",
+        time: "49 minutes ago",
+        type: "People",
+        details: "Imported from Lever and scheduled first round interview",
+      },
+      {
+        id: "activity-8",
+        user: { name: "System", initials: "SYS", avatar: null, role: "Security" },
+        action: "escalated access review",
+        target: "Financial workspace",
+        context: "Compliance",
+        time: "Today • 7:18 AM",
+        type: "Security",
+        details: "Flagged unapproved export attempt by user carol@native.local",
+        audience: "admin",
+      },
+    ],
+  },
+  {
+    id: "yesterday",
+    label: "Yesterday",
+    entries: [
+      {
+        id: "activity-4",
+        user: { name: "Alex Wilson", initials: "AW", avatar: null, role: "Product" },
+        action: "published document",
+        target: "Native roadmap v2.4",
+        context: "Product Strategy",
+        time: "Yesterday • 4:32 PM",
+        type: "Document",
+        details: "Shared with Leadership workspace and enabled change tracking",
+      },
+      {
+        id: "activity-5",
+        user: { name: "Lisa Brown", initials: "LB", avatar: null, role: "Finance" },
+        action: "created approval workflow",
+        target: "FY25 budget revisions",
+        context: "Finance > Planning",
+        time: "Yesterday • 11:18 AM",
+        type: "Workflow",
+        details: "Added approvers: Sarah Johnson, Mike Chen",
+      },
+      {
+        id: "activity-9",
+        user: { name: "System", initials: "SYS", avatar: null, role: "Security" },
+        action: "revoked session",
+        target: "Inactive admin account",
+        context: "Identity",
+        time: "Yesterday • 6:12 AM",
+        type: "Security",
+        details: "Forced sign out for account inactivity exceeding policy",
+        audience: "admin",
+      },
+    ],
+  },
+  {
+    id: "week",
+    label: "Earlier this week",
+    entries: [
+      {
+        id: "activity-6",
+        user: { name: "Priya Patel", initials: "PP", avatar: null, role: "Operations" },
+        action: "moved project stage",
+        target: "Enterprise onboarding",
+        context: "Projects",
+        time: "Monday • 9:02 AM",
+        type: "Project",
+        details: "Advanced from Discovery to Planning after client approval",
+      },
+      {
+        id: "activity-7",
+        user: { name: "Diego Martínez", initials: "DM", avatar: null, role: "Engineering" },
+        action: "created incident report",
+        target: "API latency spike",
+        context: "Statuspage",
+        time: "Monday • 7:46 AM",
+        type: "Incident",
+        details: "Documented mitigation steps and assigned follow-up tasks",
+      },
+      {
+        id: "activity-10",
+        user: { name: "Compliance Bot", initials: "CB", avatar: null, role: "Automation" },
+        action: "generated export log",
+        target: "All workspace downloads",
+        context: "Audit trail",
+        time: "Sunday • 9:30 PM",
+        type: "Audit",
+        details: "Compiled 42 file access events for weekly compliance review",
+        audience: "admin",
+      },
+    ],
+  },
+];

--- a/src/pages/AdminActivity.tsx
+++ b/src/pages/AdminActivity.tsx
@@ -1,0 +1,134 @@
+import { useMemo } from "react";
+import { ShieldCheck, ListFilter, ListOrdered } from "lucide-react";
+
+import { DashboardLayout } from "@/components/DashboardLayout";
+import { PageHeader } from "@/components/PageHeader";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { activityTimeline } from "@/data/activityTimeline";
+
+const AdminActivity = () => {
+  const flattenedEntries = useMemo(
+    () =>
+      activityTimeline.flatMap((section) =>
+        section.entries.map((entry) => ({
+          ...entry,
+          sectionId: section.id,
+        })),
+      ),
+    [],
+  );
+
+  const totalMovements = flattenedEntries.length;
+  const adminOnlyMovements = flattenedEntries.filter((entry) => entry.audience === "admin").length;
+
+  return (
+    <DashboardLayout>
+      <div className="flex min-h-screen flex-col bg-gradient-subtle">
+        <PageHeader
+          title="Admin activity monitor"
+          description="Review a complete audit feed of every workspace movement, including security events and sensitive updates."
+        />
+
+        <div className="p-6 space-y-6">
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+            <Card className="border border-border/40 bg-card/70 shadow-card/70">
+              <CardHeader className="flex flex-row items-center justify-between pb-2">
+                <CardTitle className="text-sm font-medium text-muted-foreground">Total tracked movements</CardTitle>
+                <ListOrdered className="h-4 w-4 text-accent" />
+              </CardHeader>
+              <CardContent>
+                <p className="text-2xl font-semibold text-foreground">{totalMovements}</p>
+                <p className="text-xs text-muted-foreground">Includes tasks, files, incidents, and audit events</p>
+              </CardContent>
+            </Card>
+
+            <Card className="border border-border/40 bg-card/70 shadow-card/70">
+              <CardHeader className="flex flex-row items-center justify-between pb-2">
+                <CardTitle className="text-sm font-medium text-muted-foreground">Admin-only events</CardTitle>
+                <ListFilter className="h-4 w-4 text-accent" />
+              </CardHeader>
+              <CardContent>
+                <p className="text-2xl font-semibold text-foreground">{adminOnlyMovements}</p>
+                <p className="text-xs text-muted-foreground">Security reviews, revocations, and compliance exports</p>
+              </CardContent>
+            </Card>
+
+            <Card className="border border-border/40 bg-card/70 shadow-card/70 md:col-span-2 xl:col-span-2">
+              <CardHeader className="flex flex-row items-center gap-3 pb-2">
+                <ShieldCheck className="h-5 w-5 text-accent" />
+                <div>
+                  <CardTitle className="text-sm font-medium text-foreground">Admin guidance</CardTitle>
+                  <p className="text-xs text-muted-foreground">
+                    Sensitive items are highlighted. Only administrators with elevated privileges can view this feed.
+                  </p>
+                </div>
+              </CardHeader>
+            </Card>
+          </div>
+
+          <Card className="shadow-card">
+            <CardHeader className="flex items-center gap-2">
+              <ShieldCheck className="h-5 w-5 text-accent" />
+              <CardTitle className="text-lg font-semibold text-foreground">Workspace movements</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              {activityTimeline.map((section) => (
+                <div key={section.id} className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{section.label}</p>
+                    <div className="ml-4 h-px flex-1 rounded bg-border/60" aria-hidden="true" />
+                  </div>
+
+                  <div className="space-y-2">
+                    {section.entries.map((entry) => (
+                      <div
+                        key={entry.id}
+                        className="flex gap-3 rounded-xl border border-border/60 bg-card/80 p-4 shadow-card/40"
+                      >
+                        <Avatar className="h-9 w-9">
+                          <AvatarImage src={entry.user.avatar || undefined} alt={entry.user.name} />
+                          <AvatarFallback className="bg-gradient-accent text-white text-sm">
+                            {entry.user.initials}
+                          </AvatarFallback>
+                        </Avatar>
+
+                        <div className="flex-1 space-y-2">
+                          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">
+                            <span className="font-semibold text-foreground">{entry.user.name}</span>
+                            <span className="text-muted-foreground">{entry.action}</span>
+                            <span className="font-semibold text-foreground">{entry.target}</span>
+                            {entry.audience === "admin" && (
+                              <Badge variant="secondary" className="bg-amber-500/10 text-amber-600 dark:text-amber-400">
+                                Admin only
+                              </Badge>
+                            )}
+                          </div>
+                          <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                            <Badge variant="secondary" className="text-[10px] uppercase tracking-wide">
+                              {entry.type}
+                            </Badge>
+                            <span>{entry.time}</span>
+                            <span className="hidden sm:inline">•</span>
+                            <span>{entry.context}</span>
+                          </div>
+                          <p className="text-xs text-muted-foreground/90">{entry.details}</p>
+                          <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground/80">
+                            {entry.user.role}
+                          </p>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+};
+
+export default AdminActivity;

--- a/src/pages/Notifications.tsx
+++ b/src/pages/Notifications.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from "react";
+
 import { DashboardLayout } from "@/components/DashboardLayout";
 import { PageHeader } from "@/components/PageHeader";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -5,98 +7,8 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { useToast } from "@/hooks/use-toast";
+import { activityTimeline } from "@/data/activityTimeline";
 import { BellRing, CheckCheck } from "lucide-react";
-
-const activityTimeline = [
-  {
-    id: "today",
-    label: "Today",
-    entries: [
-      {
-        id: "activity-1",
-        user: { name: "Sarah Johnson", initials: "SJ", avatar: null, role: "Product Marketing" },
-        action: "created task",
-        target: "Launch announcement brief",
-        context: "Go-to-market plan",
-        time: "12 minutes ago",
-        type: "Task",
-        details: "Set due date for Oct 12 and assigned to launch squad",
-      },
-      {
-        id: "activity-2",
-        user: { name: "Mike Chen", initials: "MC", avatar: null, role: "Client Success" },
-        action: "uploaded file",
-        target: "Q4 client review deck.pdf",
-        context: "Client Success > Q4 Reviews",
-        time: "27 minutes ago",
-        type: "File",
-        details: "Version 3.1 added with updated revenue forecasts",
-      },
-      {
-        id: "activity-3",
-        user: { name: "Emma Davis", initials: "ED", avatar: null, role: "Talent" },
-        action: "created candidate profile",
-        target: "Alex Morgan",
-        context: "Marketing Manager Hiring",
-        time: "49 minutes ago",
-        type: "People",
-        details: "Imported from Lever and scheduled first round interview",
-      },
-    ],
-  },
-  {
-    id: "yesterday",
-    label: "Yesterday",
-    entries: [
-      {
-        id: "activity-4",
-        user: { name: "Alex Wilson", initials: "AW", avatar: null, role: "Product" },
-        action: "published document",
-        target: "Native roadmap v2.4",
-        context: "Product Strategy",
-        time: "Yesterday • 4:32 PM",
-        type: "Document",
-        details: "Shared with Leadership workspace and enabled change tracking",
-      },
-      {
-        id: "activity-5",
-        user: { name: "Lisa Brown", initials: "LB", avatar: null, role: "Finance" },
-        action: "created approval workflow",
-        target: "FY25 budget revisions",
-        context: "Finance > Planning",
-        time: "Yesterday • 11:18 AM",
-        type: "Workflow",
-        details: "Added approvers: Sarah Johnson, Mike Chen",
-      },
-    ],
-  },
-  {
-    id: "week",
-    label: "Earlier this week",
-    entries: [
-      {
-        id: "activity-6",
-        user: { name: "Priya Patel", initials: "PP", avatar: null, role: "Operations" },
-        action: "moved project stage",
-        target: "Enterprise onboarding",
-        context: "Projects",
-        time: "Monday • 9:02 AM",
-        type: "Project",
-        details: "Advanced from Discovery to Planning after client approval",
-      },
-      {
-        id: "activity-7",
-        user: { name: "Diego Martínez", initials: "DM", avatar: null, role: "Engineering" },
-        action: "created incident report",
-        target: "API latency spike",
-        context: "Statuspage",
-        time: "Monday • 7:46 AM",
-        type: "Incident",
-        details: "Documented mitigation steps and assigned follow-up tasks",
-      },
-    ],
-  },
-];
 
 const Notifications = () => {
   const { toast } = useToast();
@@ -107,6 +19,17 @@ const Notifications = () => {
       description: "You're all caught up on workspace activity.",
     });
   };
+
+  const visibleTimeline = useMemo(
+    () =>
+      activityTimeline
+        .map((section) => ({
+          ...section,
+          entries: section.entries.filter((entry) => entry.audience !== "admin"),
+        }))
+        .filter((section) => section.entries.length > 0),
+    [],
+  );
 
   return (
     <DashboardLayout>
@@ -129,7 +52,7 @@ const Notifications = () => {
               <CardTitle className="text-lg font-semibold text-foreground">Recent updates</CardTitle>
             </CardHeader>
             <CardContent className="space-y-6">
-              {activityTimeline.map((section) => (
+              {visibleTimeline.map((section) => (
                 <div key={section.id} className="space-y-3">
                   <div className="flex items-center justify-between">
                     <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+
 import { DashboardLayout } from "@/components/DashboardLayout";
 import { PageHeader } from "@/components/PageHeader";
 import { Button } from "@/components/ui/button";
@@ -7,13 +9,15 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { useToast } from "@/hooks/use-toast";
-import { Save } from "lucide-react";
+import { Save, ShieldCheck } from "lucide-react";
 import { useTheme } from "next-themes";
+import { useAuth } from "@/context/AuthContext";
 
 const Settings = () => {
   const { toast } = useToast();
   const { resolvedTheme, setTheme } = useTheme();
   const [isMounted, setIsMounted] = useState(false);
+  const { user } = useAuth();
 
   useEffect(() => {
     setIsMounted(true);
@@ -40,7 +44,7 @@ const Settings = () => {
           description="Update workspace branding and notification preferences for your team."
         />
 
-        <div className="p-6">
+        <div className="p-6 space-y-6">
           <Card className="mx-auto w-full max-w-3xl shadow-card">
             <CardHeader>
               <CardTitle className="text-lg font-semibold text-foreground">Workspace preferences</CardTitle>
@@ -76,6 +80,26 @@ const Settings = () => {
               </Button>
             </CardFooter>
           </Card>
+          {user?.role?.toLowerCase() === "admin" && (
+            <Card className="mx-auto w-full max-w-3xl border border-primary/20 bg-card/80 shadow-card">
+              <CardHeader className="flex flex-row items-center gap-3">
+                <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-gradient-primary text-white">
+                  <ShieldCheck className="h-5 w-5" />
+                </div>
+                <div>
+                  <CardTitle className="text-lg font-semibold text-foreground">Administrator tools</CardTitle>
+                  <p className="text-sm text-muted-foreground">
+                    Access the workspace activity monitor to review every movement across the organization.
+                  </p>
+                </div>
+              </CardHeader>
+              <CardFooter className="flex justify-end">
+                <Button asChild className="bg-gradient-primary text-white shadow-glow">
+                  <Link to="/admin/activity">Open admin panel</Link>
+                </Button>
+              </CardFooter>
+            </Card>
+          )}
         </div>
       </div>
     </DashboardLayout>


### PR DESCRIPTION
## Summary
- add an admin-only activity monitor page with aggregated workspace movements and guidance
- centralize the activity timeline data and hide admin-only entries from the regular notifications feed
- surface an administrator tools card in settings that links admins to the new panel and guard the route with a role check

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df9767af4c8331978ac06ca56067a1