### PR TITLE
Add admin user management and soft delete support

### DIFF
--- a/native.backend/Native.Api/Controllers/UsersController.cs
+++ b/native.backend/Native.Api/Controllers/UsersController.cs
@@ -150,6 +150,7 @@ public class UsersController : ControllerBase
 
         var user = new User
         {
+            Id = Guid.NewGuid(),
             UserName = request.Email,
             Email = request.Email,
             FullName = request.FullName,

--- a/native.backend/Native.Api/Controllers/UsersController.cs
+++ b/native.backend/Native.Api/Controllers/UsersController.cs
@@ -26,10 +26,12 @@ public class UsersController : ControllerBase
 
     [HttpGet]
     [Authorize(Roles = "Admin")]
-    public IActionResult GetUsers()
+    public async Task<IActionResult> GetUsers()
     {
-        var users = _userManager.Users
+        var users = await _userManager.Users
+            .AsNoTracking()
             .Where(u => !u.IsDeleted)
+            .OrderByDescending(u => u.CreatedAt)
             .Select(u => new
             {
                 u.Id,
@@ -40,7 +42,8 @@ public class UsersController : ControllerBase
                 u.IsTwoFactorEnabled,
                 u.CreatedAt
             })
-            .OrderByDescending(u => u.CreatedAt);
+            .ToListAsync();
+
         return Ok(users);
     }
 

--- a/native.backend/Native.Api/Controllers/UsersController.cs
+++ b/native.backend/Native.Api/Controllers/UsersController.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Native.Api.DTOs;
 using Native.Core.Entities;
 
@@ -24,10 +25,11 @@ public class UsersController : ControllerBase
     }
 
     [HttpGet]
-    [Authorize(Roles = "Admin,Manager")]
+    [Authorize(Roles = "Admin")]
     public IActionResult GetUsers()
     {
         var users = _userManager.Users
+            .Where(u => !u.IsDeleted)
             .Select(u => new
             {
                 u.Id,
@@ -37,7 +39,8 @@ public class UsersController : ControllerBase
                 u.OrganizationId,
                 u.IsTwoFactorEnabled,
                 u.CreatedAt
-            });
+            })
+            .OrderByDescending(u => u.CreatedAt);
         return Ok(users);
     }
 
@@ -56,11 +59,11 @@ public class UsersController : ControllerBase
     }
 
     [HttpGet("{id:guid}")]
-    [Authorize(Roles = "Admin,Manager")]
+    [Authorize(Roles = "Admin")]
     public async Task<IActionResult> GetUser(Guid id)
     {
         var user = await _userManager.FindByIdAsync(id.ToString());
-        if (user is null)
+        if (user is null || user.IsDeleted)
         {
             return NotFound();
         }
@@ -77,12 +80,110 @@ public class UsersController : ControllerBase
         });
     }
 
+    [HttpPost]
+    [Authorize(Roles = "Admin")]
+    public async Task<IActionResult> CreateUser(CreateUserRequest request)
+    {
+        var trimmedRole = request.Role?.Trim();
+        var roleName = string.IsNullOrWhiteSpace(trimmedRole) ? "User" : trimmedRole!;
+        if (!await _roleManager.RoleExistsAsync(roleName))
+        {
+            await _roleManager.CreateAsync(new IdentityRole<Guid>(roleName));
+        }
+
+        var normalizedEmail = _userManager.NormalizeEmail(request.Email);
+        var existing = await _userManager.Users
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(u => u.NormalizedEmail == normalizedEmail);
+
+        if (existing is not null)
+        {
+            if (!existing.IsDeleted)
+            {
+                return Conflict(new { message = "A user with this email already exists." });
+            }
+
+            existing.FullName = request.FullName;
+            existing.Role = roleName;
+            existing.OrganizationId = request.OrganizationId;
+            existing.UserName = request.Email;
+            existing.Email = request.Email;
+            existing.NormalizedEmail = normalizedEmail;
+            existing.NormalizedUserName = _userManager.NormalizeName(request.Email);
+            existing.IsDeleted = false;
+            existing.IsTwoFactorEnabled = false;
+            existing.LockoutEnd = null;
+            existing.LockoutEnabled = true;
+            existing.AccessFailedCount = 0;
+
+            var currentRoles = await _userManager.GetRolesAsync(existing);
+            if (currentRoles.Any())
+            {
+                await _userManager.RemoveFromRolesAsync(existing, currentRoles);
+            }
+
+            await _userManager.AddToRoleAsync(existing, roleName);
+
+            existing.PasswordHash = _userManager.PasswordHasher.HashPassword(existing, request.Password);
+            await _userManager.UpdateSecurityStampAsync(existing);
+
+            var reactivateResult = await _userManager.UpdateAsync(existing);
+            if (!reactivateResult.Succeeded)
+            {
+                return BadRequest(new { errors = reactivateResult.Errors.Select(e => e.Description) });
+            }
+
+            return Ok(new
+            {
+                existing.Id,
+                existing.Email,
+                existing.FullName,
+                existing.Role,
+                existing.OrganizationId,
+                existing.IsTwoFactorEnabled,
+                existing.CreatedAt
+            });
+        }
+
+        var user = new User
+        {
+            UserName = request.Email,
+            Email = request.Email,
+            FullName = request.FullName,
+            Role = roleName,
+            OrganizationId = request.OrganizationId,
+            IsTwoFactorEnabled = false
+        };
+
+        var createResult = await _userManager.CreateAsync(user, request.Password);
+        if (!createResult.Succeeded)
+        {
+            return BadRequest(new { errors = createResult.Errors.Select(e => e.Description) });
+        }
+
+        await _userManager.AddToRoleAsync(user, roleName);
+
+        return CreatedAtAction(
+            nameof(GetUser),
+            new { id = user.Id },
+            new
+            {
+                user.Id,
+                user.Email,
+                user.FullName,
+                user.Role,
+                user.OrganizationId,
+                user.IsTwoFactorEnabled,
+                user.CreatedAt
+            });
+    }
+
     [HttpPatch("{id:guid}")]
-    [Authorize(Roles = "Admin,Manager")]
+    [Authorize(Roles = "Admin")]
     public async Task<IActionResult> UpdateUser(Guid id, UpdateUserRequest request)
     {
         var user = await _userManager.FindByIdAsync(id.ToString());
-        if (user is null)
+        if (user is null || user.IsDeleted)
         {
             return NotFound();
         }
@@ -129,5 +230,37 @@ public class UsersController : ControllerBase
             user.OrganizationId,
             user.IsTwoFactorEnabled
         });
+    }
+
+    [HttpDelete("{id:guid}")]
+    [Authorize(Roles = "Admin")]
+    public async Task<IActionResult> DeleteUser(Guid id)
+    {
+        var user = await _userManager.Users
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(u => u.Id == id);
+
+        if (user is null)
+        {
+            return NotFound();
+        }
+
+        if (user.IsDeleted)
+        {
+            return NoContent();
+        }
+
+        user.IsDeleted = true;
+        user.LockoutEnabled = true;
+        user.LockoutEnd = DateTimeOffset.MaxValue;
+        await _userManager.UpdateSecurityStampAsync(user);
+
+        var result = await _userManager.UpdateAsync(user);
+        if (!result.Succeeded)
+        {
+            return BadRequest(new { errors = result.Errors.Select(e => e.Description) });
+        }
+
+        return NoContent();
     }
 }

--- a/native.backend/Native.Api/DTOs/CreateUserRequest.cs
+++ b/native.backend/Native.Api/DTOs/CreateUserRequest.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Native.Api.DTOs;
+
+public record CreateUserRequest(
+    string Email,
+    string Password,
+    string FullName,
+    string? Role,
+    Guid? OrganizationId);

--- a/native.backend/Native.Api/DTOs/Validators/CreateUserRequestValidator.cs
+++ b/native.backend/Native.Api/DTOs/Validators/CreateUserRequestValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+
+namespace Native.Api.DTOs.Validators;
+
+public class CreateUserRequestValidator : AbstractValidator<CreateUserRequest>
+{
+    public CreateUserRequestValidator()
+    {
+        RuleFor(x => x.Email).NotEmpty().EmailAddress();
+        RuleFor(x => x.Password).NotEmpty().MinimumLength(6);
+        RuleFor(x => x.FullName).NotEmpty().MaximumLength(256);
+        RuleFor(x => x.Role).MaximumLength(64);
+    }
+}

--- a/native.backend/Native.Core/Entities/CalendarBoard.cs
+++ b/native.backend/Native.Core/Entities/CalendarBoard.cs
@@ -1,9 +1,10 @@
 using System;
 using System.Collections.Generic;
+using Native.Core.Interfaces;
 
 namespace Native.Core.Entities;
 
-public class CalendarBoard
+public class CalendarBoard : ISoftDeletable
 {
     public Guid Id { get; set; }
     public Guid OwnerId { get; set; }
@@ -11,4 +12,5 @@ public class CalendarBoard
     public CalendarVisibility Visibility { get; set; } = CalendarVisibility.Private;
     public ICollection<CalendarEvent> Events { get; set; } = new List<CalendarEvent>();
     public ICollection<CalendarShare> SharedUsers { get; set; } = new List<CalendarShare>();
+    public bool IsDeleted { get; set; }
 }

--- a/native.backend/Native.Core/Entities/CalendarEvent.cs
+++ b/native.backend/Native.Core/Entities/CalendarEvent.cs
@@ -1,8 +1,10 @@
 using System;
 
+using Native.Core.Interfaces;
+
 namespace Native.Core.Entities;
 
-public class CalendarEvent
+public class CalendarEvent : ISoftDeletable
 {
     public Guid Id { get; set; }
     public Guid CalendarId { get; set; }
@@ -17,4 +19,5 @@ public class CalendarEvent
     public string ExternalEventId { get; set; } = string.Empty;
     [System.Text.Json.Serialization.JsonIgnore]
     public CalendarBoard? Calendar { get; set; }
+    public bool IsDeleted { get; set; }
 }

--- a/native.backend/Native.Core/Entities/CalendarShare.cs
+++ b/native.backend/Native.Core/Entities/CalendarShare.cs
@@ -1,13 +1,15 @@
 using System;
 using System.Text.Json.Serialization;
+using Native.Core.Interfaces;
 
 namespace Native.Core.Entities;
 
-public class CalendarShare
+public class CalendarShare : ISoftDeletable
 {
     public Guid CalendarId { get; set; }
     public Guid UserId { get; set; }
 
     [JsonIgnore]
     public CalendarBoard? Calendar { get; set; }
+    public bool IsDeleted { get; set; }
 }

--- a/native.backend/Native.Core/Entities/IntegrationConnection.cs
+++ b/native.backend/Native.Core/Entities/IntegrationConnection.cs
@@ -1,8 +1,10 @@
 using System;
 
+using Native.Core.Interfaces;
+
 namespace Native.Core.Entities;
 
-public class IntegrationConnection
+public class IntegrationConnection : ISoftDeletable
 {
     public Guid Id { get; set; }
     public Guid UserId { get; set; }
@@ -13,4 +15,5 @@ public class IntegrationConnection
     public string? AccountId { get; set; }
     public DateTime? ExpiresAt { get; set; }
     public DateTime ConnectedAt { get; set; } = DateTime.UtcNow;
+    public bool IsDeleted { get; set; }
 }

--- a/native.backend/Native.Core/Entities/JobApplication.cs
+++ b/native.backend/Native.Core/Entities/JobApplication.cs
@@ -1,8 +1,10 @@
 using System;
 
+using Native.Core.Interfaces;
+
 namespace Native.Core.Entities;
 
-public class JobApplication
+public class JobApplication : ISoftDeletable
 {
     public Guid Id { get; set; }
     public Guid JobOpeningId { get; set; }
@@ -13,4 +15,5 @@ public class JobApplication
     public string? ResumeUrl { get; set; }
     public string? Notes { get; set; }
     public DateTime AppliedAt { get; set; } = DateTime.UtcNow;
+    public bool IsDeleted { get; set; }
 }

--- a/native.backend/Native.Core/Entities/JobOpening.cs
+++ b/native.backend/Native.Core/Entities/JobOpening.cs
@@ -1,9 +1,10 @@
 using System;
 using System.Collections.Generic;
+using Native.Core.Interfaces;
 
 namespace Native.Core.Entities;
 
-public class JobOpening
+public class JobOpening : ISoftDeletable
 {
     public Guid Id { get; set; }
     public Guid OrgId { get; set; }
@@ -14,4 +15,5 @@ public class JobOpening
     public bool IsPublished { get; set; }
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public ICollection<JobApplication> Applications { get; set; } = new List<JobApplication>();
+    public bool IsDeleted { get; set; }
 }

--- a/native.backend/Native.Core/Entities/Organization.cs
+++ b/native.backend/Native.Core/Entities/Organization.cs
@@ -1,13 +1,15 @@
 using System;
 using System.Collections.Generic;
+using Native.Core.Interfaces;
 
 namespace Native.Core.Entities;
 
-public class Organization
+public class Organization : ISoftDeletable
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = default!;
     public string? Domain { get; set; }
     public string? SettingsJson { get; set; }
     public ICollection<User> Users { get; set; } = new List<User>();
+    public bool IsDeleted { get; set; }
 }

--- a/native.backend/Native.Core/Entities/Project.cs
+++ b/native.backend/Native.Core/Entities/Project.cs
@@ -1,9 +1,10 @@
 using System;
 using System.Collections.Generic;
+using Native.Core.Interfaces;
 
 namespace Native.Core.Entities;
 
-public class Project
+public class Project : ISoftDeletable
 {
     public Guid Id { get; set; }
     public Guid OrgId { get; set; }
@@ -11,4 +12,5 @@ public class Project
     public string? Description { get; set; }
     public string Color { get; set; } = "#7c3aed";
     public ICollection<TaskItem> Tasks { get; set; } = new List<TaskItem>();
+    public bool IsDeleted { get; set; }
 }

--- a/native.backend/Native.Core/Entities/TaskAttachment.cs
+++ b/native.backend/Native.Core/Entities/TaskAttachment.cs
@@ -1,8 +1,10 @@
 using System;
 
+using Native.Core.Interfaces;
+
 namespace Native.Core.Entities;
 
-public class TaskAttachment
+public class TaskAttachment : ISoftDeletable
 {
     public Guid Id { get; set; }
     public Guid TaskId { get; set; }
@@ -11,4 +13,5 @@ public class TaskAttachment
     public string Provider { get; set; } = "dropbox";
     public Guid? LinkedById { get; set; }
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public bool IsDeleted { get; set; }
 }

--- a/native.backend/Native.Core/Entities/TaskItem.cs
+++ b/native.backend/Native.Core/Entities/TaskItem.cs
@@ -1,9 +1,10 @@
 using System;
 using System.Collections.Generic;
+using Native.Core.Interfaces;
 
 namespace Native.Core.Entities;
 
-public class TaskItem
+public class TaskItem : ISoftDeletable
 {
     public Guid Id { get; set; }
     public Guid? ProjectId { get; set; }
@@ -17,4 +18,5 @@ public class TaskItem
     public DateTime? CompletedAt { get; set; }
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public ICollection<TaskAttachment> Attachments { get; set; } = new List<TaskAttachment>();
+    public bool IsDeleted { get; set; }
 }

--- a/native.backend/Native.Core/Entities/User.cs
+++ b/native.backend/Native.Core/Entities/User.cs
@@ -1,13 +1,15 @@
 using System;
 using Microsoft.AspNetCore.Identity;
+using Native.Core.Interfaces;
 
 namespace Native.Core.Entities;
 
-public class User : IdentityUser<Guid>
+public class User : IdentityUser<Guid>, ISoftDeletable
 {
     public string FullName { get; set; } = default!;
     public string Role { get; set; } = "User";
     public Guid? OrganizationId { get; set; }
     public bool IsTwoFactorEnabled { get; set; }
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public bool IsDeleted { get; set; }
 }

--- a/native.backend/Native.Core/Interfaces/ISoftDeletable.cs
+++ b/native.backend/Native.Core/Interfaces/ISoftDeletable.cs
@@ -1,0 +1,6 @@
+namespace Native.Core.Interfaces;
+
+public interface ISoftDeletable
+{
+    bool IsDeleted { get; set; }
+}

--- a/native.backend/Native.Core/Services/AuthService.cs
+++ b/native.backend/Native.Core/Services/AuthService.cs
@@ -50,7 +50,7 @@ public class AuthService : IAuthService
     public async Task<AuthResult?> LoginAsync(string email, string password, CancellationToken cancellationToken = default)
     {
         var user = await _userManager.FindByEmailAsync(email);
-        if (user is null)
+        if (user is null || user.IsDeleted)
         {
             return null;
         }

--- a/native.backend/Native.Infrastructure/Repositories/CalendarBoardRepository.cs
+++ b/native.backend/Native.Infrastructure/Repositories/CalendarBoardRepository.cs
@@ -43,7 +43,8 @@ public class CalendarBoardRepository : GenericRepository<CalendarBoard>, ICalend
     public async Task<CalendarBoard?> GetWithSharesAsync(Guid calendarId, CancellationToken cancellationToken = default)
     {
         return await Context.Calendars
+            .IgnoreQueryFilters()
             .Include(c => c.SharedUsers)
-            .FirstOrDefaultAsync(c => c.Id == calendarId, cancellationToken);
+            .FirstOrDefaultAsync(c => c.Id == calendarId && !c.IsDeleted, cancellationToken);
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import Goals from "./pages/Goals";
 import TimeOff from "./pages/TimeOff";
 import AdminActivity from "./pages/AdminActivity";
 import AdminUsers from "./pages/AdminUsers";
+import AdminPanel from "./pages/AdminPanel";
 import { AuthProvider } from "./context/AuthContext";
 import { RequireAuth } from "./components/RequireAuth";
 import { RequireAdmin } from "./components/RequireAdmin";
@@ -50,6 +51,7 @@ const App = () => (
               <Route path="/goals" element={<Goals />} />
               <Route path="/time-off" element={<TimeOff />} />
               <Route element={<RequireAdmin />}>
+                <Route path="/admin" element={<AdminPanel />} />
                 <Route path="/admin/activity" element={<AdminActivity />} />
                 <Route path="/admin/users" element={<AdminUsers />} />
               </Route>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import Register from "./pages/Register";
 import Goals from "./pages/Goals";
 import TimeOff from "./pages/TimeOff";
 import AdminActivity from "./pages/AdminActivity";
+import AdminUsers from "./pages/AdminUsers";
 import { AuthProvider } from "./context/AuthContext";
 import { RequireAuth } from "./components/RequireAuth";
 import { RequireAdmin } from "./components/RequireAdmin";
@@ -50,6 +51,7 @@ const App = () => (
               <Route path="/time-off" element={<TimeOff />} />
               <Route element={<RequireAdmin />}>
                 <Route path="/admin/activity" element={<AdminActivity />} />
+                <Route path="/admin/users" element={<AdminUsers />} />
               </Route>
             </Route>
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -12,8 +12,6 @@ import {
   Layout,
   FileText,
   CalendarClock,
-  ShieldCheck,
-  Users,
 } from "lucide-react";
 
 import {
@@ -53,11 +51,6 @@ const resourcesNavItems = [
   { title: "Dashboards", url: "/dashboards", icon: Layout },
   { title: "Docs", url: "/files", icon: FileText },
   { title: "Settings", url: "/settings", icon: Settings },
-];
-
-const adminNavItems = [
-  { title: "Admin activity", url: "/admin/activity", icon: ShieldCheck },
-  { title: "Users", url: "/admin/users", icon: Users },
 ];
 
 export function AppSidebar() {
@@ -238,38 +231,6 @@ export function AppSidebar() {
               </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>
-
-        {user?.role?.toLowerCase() === "admin" && (
-          <SidebarGroup className="mt-6">
-            <SidebarGroupLabel className={collapsed ? "sr-only" : "uppercase tracking-wide text-xs text-muted-foreground"}>
-              Admin
-            </SidebarGroupLabel>
-            <SidebarGroupContent>
-              <SidebarMenu className={cn("space-y-1", collapsed && "space-y-0 gap-3")}>
-                {adminNavItems.map((item) => (
-                  <SidebarMenuItem key={item.title}>
-                    <SidebarMenuButton asChild>
-                      <NavLink
-                        to={item.url}
-                        title={collapsed ? item.title : undefined}
-                        className={({ isActive }) => getNavCls({ isActive })}
-                      >
-                        <item.icon
-                          className={cn(
-                            "flex-shrink-0 transition-transform",
-                            collapsed ? "h-8 w-8" : "h-6 w-6",
-                            collapsed && "mx-auto",
-                          )}
-                        />
-                        {!collapsed && <span className="ml-3">{item.title}</span>}
-                      </NavLink>
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                ))}
-              </SidebarMenu>
-            </SidebarGroupContent>
-          </SidebarGroup>
-        )}
 
         <div
           className={cn(

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -12,6 +12,8 @@ import {
   Layout,
   FileText,
   CalendarClock,
+  ShieldCheck,
+  Users,
 } from "lucide-react";
 
 import {
@@ -51,6 +53,11 @@ const resourcesNavItems = [
   { title: "Dashboards", url: "/dashboards", icon: Layout },
   { title: "Docs", url: "/files", icon: FileText },
   { title: "Settings", url: "/settings", icon: Settings },
+];
+
+const adminNavItems = [
+  { title: "Admin activity", url: "/admin/activity", icon: ShieldCheck },
+  { title: "Users", url: "/admin/users", icon: Users },
 ];
 
 export function AppSidebar() {
@@ -229,14 +236,46 @@ export function AppSidebar() {
                   </SidebarMenuItem>
                 ))}
               </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+
+        {user?.role?.toLowerCase() === "admin" && (
+          <SidebarGroup className="mt-6">
+            <SidebarGroupLabel className={collapsed ? "sr-only" : "uppercase tracking-wide text-xs text-muted-foreground"}>
+              Admin
+            </SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu className={cn("space-y-1", collapsed && "space-y-0 gap-3")}>
+                {adminNavItems.map((item) => (
+                  <SidebarMenuItem key={item.title}>
+                    <SidebarMenuButton asChild>
+                      <NavLink
+                        to={item.url}
+                        title={collapsed ? item.title : undefined}
+                        className={({ isActive }) => getNavCls({ isActive })}
+                      >
+                        <item.icon
+                          className={cn(
+                            "flex-shrink-0 transition-transform",
+                            collapsed ? "h-8 w-8" : "h-6 w-6",
+                            collapsed && "mx-auto",
+                          )}
+                        />
+                        {!collapsed && <span className="ml-3">{item.title}</span>}
+                      </NavLink>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                ))}
+              </SidebarMenu>
             </SidebarGroupContent>
           </SidebarGroup>
+        )}
 
-          <div
-            className={cn(
-              "mt-auto pt-6",
-              collapsed && "pb-10",
-            )}
+        <div
+          className={cn(
+            "mt-auto pt-6",
+            collapsed && "pb-10",
+          )}
           >
             <Button
               variant="ghost"

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,8 +1,21 @@
-const API_BASE_URL =
-  import.meta.env.VITE_API_URL ??
-  (typeof window !== "undefined" && window.location.hostname !== "localhost"
-    ? window.location.origin
-    : "https://localhost:5001");
+const API_BASE_URL = (() => {
+  if (import.meta.env.VITE_API_URL) {
+    return import.meta.env.VITE_API_URL;
+  }
+
+  if (typeof window === "undefined") {
+    return "";
+  }
+
+  const host = window.location.hostname;
+  const isLocalHost =
+    host === "localhost" ||
+    host === "127.0.0.1" ||
+    host === "0.0.0.0" ||
+    host.endsWith(".localhost");
+
+  return isLocalHost ? "https://localhost:5001" : window.location.origin;
+})();
 
 async function request<T>(
   path: string,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -67,6 +67,56 @@ export const registerRequest = (payload: RegisterPayload) =>
     body: JSON.stringify(payload),
   });
 
+export interface AdminUser {
+  id: string;
+  email: string;
+  fullName: string;
+  role: string;
+  organizationId?: string | null;
+  isTwoFactorEnabled: boolean;
+  createdAt: string;
+}
+
+export interface CreateUserPayload {
+  email: string;
+  password: string;
+  fullName: string;
+  role?: string | null;
+  organizationId?: string | null;
+}
+
+export interface UpdateUserPayload {
+  fullName?: string;
+  role?: string | null;
+  twoFactorEnabled?: boolean;
+}
+
+export const fetchUsers = (token: string) =>
+  request<AdminUser[]>("/api/users", {
+    method: "GET",
+    token,
+  });
+
+export const createUser = (token: string, payload: CreateUserPayload) =>
+  request<AdminUser>("/api/users", {
+    method: "POST",
+    token,
+    body: JSON.stringify(payload),
+  });
+
+export const updateUser = (token: string, userId: string, payload: UpdateUserPayload) =>
+  request<AdminUser>(`/api/users/${userId}`, {
+    method: "PATCH",
+    token,
+    body: JSON.stringify(payload),
+  });
+
+export const deleteUser = (token: string, userId: string) =>
+  request<void>(`/api/users/${userId}`, {
+    method: "DELETE",
+    token,
+  });
+
 export interface TaskInput {
   projectId?: string | null;
   title: string;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,8 @@
-const API_BASE_URL = import.meta.env.VITE_API_URL ?? "http://localhost:5000";
+const API_BASE_URL =
+  import.meta.env.VITE_API_URL ??
+  (typeof window !== "undefined" && window.location.hostname !== "localhost"
+    ? window.location.origin
+    : "https://localhost:5001");
 
 async function request<T>(
   path: string,

--- a/src/pages/AdminActivity.tsx
+++ b/src/pages/AdminActivity.tsx
@@ -1,8 +1,10 @@
 import { useMemo } from "react";
 import { ShieldCheck, ListFilter, ListOrdered } from "lucide-react";
+import { Link } from "react-router-dom";
 
 import { DashboardLayout } from "@/components/DashboardLayout";
 import { PageHeader } from "@/components/PageHeader";
+import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -29,6 +31,11 @@ const AdminActivity = () => {
         <PageHeader
           title="Admin activity monitor"
           description="Review a complete audit feed of every workspace movement, including security events and sensitive updates."
+          actions={
+            <Button variant="outline" size="sm" asChild>
+              <Link to="/admin">Admin panel</Link>
+            </Button>
+          }
         />
 
         <div className="p-6 space-y-6">

--- a/src/pages/AdminPanel.tsx
+++ b/src/pages/AdminPanel.tsx
@@ -1,0 +1,111 @@
+import { Link } from "react-router-dom";
+import { ShieldCheck, Users, Activity } from "lucide-react";
+
+import { DashboardLayout } from "@/components/DashboardLayout";
+import { PageHeader } from "@/components/PageHeader";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+const adminTools = [
+  {
+    title: "User management",
+    description: "Invite teammates, assign roles, and deactivate accounts when access should be revoked.",
+    highlights: [
+      "Create new users with predefined roles and optional organization scopes.",
+      "Edit profile information, update roles, and enforce two-factor authentication.",
+      "Soft delete members to immediately suspend access while keeping audit history.",
+    ],
+    icon: Users,
+    cta: "Manage users",
+    to: "/admin/users",
+  },
+  {
+    title: "Activity monitor",
+    description: "Review sensitive changes, download audit trails, and verify compliance posture.",
+    highlights: [
+      "Filter notable workspace movements to focus on admin-only events.",
+      "Surface sign-in attempts, permission updates, and data exports in one place.",
+      "Share guidance with fellow administrators to maintain least-privilege policies.",
+    ],
+    icon: Activity,
+    cta: "View activity",
+    to: "/admin/activity",
+  },
+];
+
+const AdminPanel = () => {
+  return (
+    <DashboardLayout>
+      <div className="flex min-h-screen flex-col bg-gradient-subtle">
+        <PageHeader
+          title="Administrator control center"
+          description="Access security tooling reserved for administrators to manage members and monitor high-impact activity."
+        />
+
+        <div className="p-6 space-y-6">
+          <Card className="border border-border/50 bg-card/80 shadow-card">
+            <CardHeader className="flex flex-wrap items-center justify-between gap-4">
+              <div className="flex items-center gap-3">
+                <div className="flex h-11 w-11 items-center justify-center rounded-lg bg-gradient-primary text-white">
+                  <ShieldCheck className="h-5 w-5" />
+                </div>
+                <div>
+                  <CardTitle className="text-lg font-semibold text-foreground">Workspace security overview</CardTitle>
+                  <CardDescription className="text-sm text-muted-foreground">
+                    These tools are only visible to workspace administrators. Keep credentials secure and audit access often.
+                  </CardDescription>
+                </div>
+              </div>
+              <Badge variant="secondary" className="bg-amber-500/10 text-amber-600 dark:text-amber-400">
+                Admin only
+              </Badge>
+            </CardHeader>
+          </Card>
+
+          <div className="grid gap-6 lg:grid-cols-2">
+            {adminTools.map((tool) => (
+              <Card key={tool.title} className="h-full border border-border/40 bg-card/90 shadow-card/80">
+                <CardHeader className="flex flex-col gap-3">
+                  <div className="flex items-center gap-3">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-muted text-primary">
+                      <tool.icon className="h-5 w-5" />
+                    </div>
+                    <div>
+                      <CardTitle className="text-lg font-semibold text-foreground">{tool.title}</CardTitle>
+                      <CardDescription className="text-sm text-muted-foreground">{tool.description}</CardDescription>
+                    </div>
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  <ul className="space-y-3 text-sm text-muted-foreground">
+                    {tool.highlights.map((highlight) => (
+                      <li key={highlight} className="flex gap-2">
+                        <span className="mt-1 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-primary/80" aria-hidden="true" />
+                        <span>{highlight}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </CardContent>
+                <CardFooter className="flex justify-end">
+                  <Button asChild className="bg-gradient-primary text-white shadow-glow">
+                    <Link to={tool.to}>{tool.cta}</Link>
+                  </Button>
+                </CardFooter>
+              </Card>
+            ))}
+          </div>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+};
+
+export default AdminPanel;

--- a/src/pages/AdminUsers.tsx
+++ b/src/pages/AdminUsers.tsx
@@ -1,0 +1,525 @@
+import { useMemo, useState } from "react";
+import { useForm } from "react-hook-form";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { DashboardLayout } from "@/components/DashboardLayout";
+import { PageHeader } from "@/components/PageHeader";
+import { useAuth } from "@/context/AuthContext";
+import {
+  AdminUser,
+  CreateUserPayload,
+  UpdateUserPayload,
+  createUser,
+  deleteUser,
+  fetchUsers,
+  updateUser,
+} from "@/lib/api";
+import { useToast } from "@/hooks/use-toast";
+import { Loader2, ShieldCheck, Trash2, UserPlus, PencilLine } from "lucide-react";
+
+interface CreateUserFormValues {
+  fullName: string;
+  email: string;
+  password: string;
+  role: string;
+  organizationId: string;
+}
+
+interface UpdateUserFormValues {
+  fullName: string;
+  role: string;
+  twoFactorEnabled: boolean;
+}
+
+const defaultCreateValues: CreateUserFormValues = {
+  fullName: "",
+  email: "",
+  password: "",
+  role: "User",
+  organizationId: "",
+};
+
+const roleOptions = ["Admin", "Manager", "User"];
+
+const AdminUsers = () => {
+  const { token } = useAuth();
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const [isCreateOpen, setCreateOpen] = useState(false);
+  const [isEditOpen, setEditOpen] = useState(false);
+  const [editingUser, setEditingUser] = useState<AdminUser | null>(null);
+  const [userToDelete, setUserToDelete] = useState<AdminUser | null>(null);
+
+  const usersQuery = useQuery<AdminUser[], Error>({
+    queryKey: ["admin-users"],
+    queryFn: () => fetchUsers(token!),
+    enabled: Boolean(token),
+  });
+
+  const createForm = useForm<CreateUserFormValues>({
+    defaultValues: defaultCreateValues,
+  });
+
+  const updateForm = useForm<UpdateUserFormValues>({
+    defaultValues: { fullName: "", role: "User", twoFactorEnabled: false },
+  });
+
+  const createMutation = useMutation({
+    mutationFn: async (values: CreateUserFormValues) => {
+      const payload: CreateUserPayload = {
+        fullName: values.fullName,
+        email: values.email,
+        password: values.password,
+        role: values.role,
+        organizationId: values.organizationId.trim() ? values.organizationId.trim() : null,
+      };
+      return createUser(token!, payload);
+    },
+    onSuccess: () => {
+      toast({
+        title: "User created",
+        description: "The new user can now access the workspace.",
+      });
+      setCreateOpen(false);
+      createForm.reset(defaultCreateValues);
+      queryClient.invalidateQueries({ queryKey: ["admin-users"] });
+    },
+    onError: (error: Error) => {
+      toast({
+        title: "Failed to create user",
+        description: error.message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: async (values: UpdateUserFormValues) => {
+      if (!editingUser) return Promise.reject(new Error("No user selected"));
+      const payload: UpdateUserPayload = {
+        fullName: values.fullName,
+        role: values.role,
+        twoFactorEnabled: values.twoFactorEnabled,
+      };
+      return updateUser(token!, editingUser.id, payload);
+    },
+    onSuccess: () => {
+      toast({
+        title: "User updated",
+        description: "Changes were saved successfully.",
+      });
+      setEditOpen(false);
+      setEditingUser(null);
+      queryClient.invalidateQueries({ queryKey: ["admin-users"] });
+    },
+    onError: (error: Error) => {
+      toast({
+        title: "Failed to update user",
+        description: error.message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (userId: string) => deleteUser(token!, userId),
+    onSuccess: () => {
+      toast({
+        title: "User removed",
+        description: "The user was soft deleted and can no longer sign in.",
+      });
+      queryClient.invalidateQueries({ queryKey: ["admin-users"] });
+      setUserToDelete(null);
+    },
+    onError: (error: Error) => {
+      toast({
+        title: "Failed to delete user",
+        description: error.message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const users = useMemo(() => usersQuery.data ?? [], [usersQuery.data]);
+
+  const handleEdit = (user: AdminUser) => {
+    setEditingUser(user);
+    updateForm.reset({
+      fullName: user.fullName,
+      role: user.role,
+      twoFactorEnabled: user.isTwoFactorEnabled,
+    });
+    setEditOpen(true);
+  };
+
+  const formatDate = (value: string) =>
+    new Intl.DateTimeFormat(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    }).format(new Date(value));
+
+  return (
+    <DashboardLayout>
+      <div className="flex min-h-screen flex-col bg-gradient-subtle">
+        <PageHeader
+          title="User management"
+          description="Create, update, or deactivate workspace members. Only administrators can see this area."
+          actions={(
+            <Dialog open={isCreateOpen} onOpenChange={(open) => {
+              setCreateOpen(open);
+              if (!open) {
+                createForm.reset(defaultCreateValues);
+              }
+            }}>
+              <DialogTrigger asChild>
+                <Button size="sm" className="gap-2 bg-gradient-primary text-white shadow-glow">
+                  <UserPlus className="h-4 w-4" />
+                  New user
+                </Button>
+              </DialogTrigger>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>Create user</DialogTitle>
+                  <DialogDescription>Invite a new teammate with the appropriate role.</DialogDescription>
+                </DialogHeader>
+                <Form {...createForm}>
+                  <form
+                    onSubmit={createForm.handleSubmit((values) => createMutation.mutate(values))}
+                    className="space-y-4"
+                  >
+                    <FormField
+                      control={createForm.control}
+                      name="fullName"
+                      rules={{ required: "Full name is required" }}
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Full name</FormLabel>
+                          <FormControl>
+                            <Input placeholder="Jane Doe" {...field} />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={createForm.control}
+                      name="email"
+                      rules={{ required: "Email is required" }}
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Email</FormLabel>
+                          <FormControl>
+                            <Input type="email" placeholder="jane@example.com" {...field} />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={createForm.control}
+                      name="password"
+                      rules={{ required: "Password is required", minLength: { value: 6, message: "At least 6 characters" } }}
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Temporary password</FormLabel>
+                          <FormControl>
+                            <Input type="password" placeholder="••••••" {...field} />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={createForm.control}
+                      name="role"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Role</FormLabel>
+                          <Select onValueChange={field.onChange} value={field.value}>
+                            <FormControl>
+                              <SelectTrigger>
+                                <SelectValue placeholder="Select a role" />
+                              </SelectTrigger>
+                            </FormControl>
+                            <SelectContent>
+                              {roleOptions.map((role) => (
+                                <SelectItem key={role} value={role}>
+                                  {role}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={createForm.control}
+                      name="organizationId"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Organization ID</FormLabel>
+                          <FormControl>
+                            <Input placeholder="Optional" {...field} />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <DialogFooter>
+                      <Button type="submit" disabled={createMutation.isPending} className="gap-2">
+                        {createMutation.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
+                        Create user
+                      </Button>
+                    </DialogFooter>
+                  </form>
+                </Form>
+              </DialogContent>
+            </Dialog>
+          )}
+        />
+
+        <div className="p-6">
+          <Card className="shadow-card">
+            <CardHeader className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+              <div>
+                <CardTitle className="flex items-center gap-2 text-lg font-semibold text-foreground">
+                  <ShieldCheck className="h-5 w-5 text-accent" />
+                  Workspace members
+                </CardTitle>
+                <CardDescription className="text-sm text-muted-foreground">
+                  Monitor active accounts and enforce least-privilege access.
+                </CardDescription>
+              </div>
+              <Badge variant="secondary" className="text-xs">
+                {users.length} users
+              </Badge>
+            </CardHeader>
+            <CardContent>
+              {usersQuery.isLoading ? (
+                <div className="flex items-center justify-center py-12 text-muted-foreground">
+                  <Loader2 className="h-5 w-5 animate-spin" />
+                  <span className="ml-2 text-sm">Loading users…</span>
+                </div>
+              ) : usersQuery.isError ? (
+                <div className="rounded-lg border border-dashed border-destructive/40 bg-destructive/5 py-12 text-center text-sm text-destructive">
+                  {usersQuery.error.message}
+                </div>
+              ) : users.length === 0 ? (
+                <div className="rounded-lg border border-dashed border-border/60 bg-muted/30 py-12 text-center text-sm text-muted-foreground">
+                  No users found. Create a new member to get started.
+                </div>
+              ) : (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Name</TableHead>
+                      <TableHead>Email</TableHead>
+                      <TableHead>Role</TableHead>
+                      <TableHead>2FA</TableHead>
+                      <TableHead>Created</TableHead>
+                      <TableHead className="w-[120px] text-right">Actions</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {users.map((user) => (
+                      <TableRow key={user.id}>
+                        <TableCell className="font-medium text-foreground">{user.fullName}</TableCell>
+                        <TableCell className="text-muted-foreground">{user.email}</TableCell>
+                        <TableCell>
+                          <Badge variant="outline" className="capitalize">
+                            {user.role.toLowerCase()}
+                          </Badge>
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant={user.isTwoFactorEnabled ? "secondary" : "outline"} className="text-xs">
+                            {user.isTwoFactorEnabled ? "Enabled" : "Disabled"}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="text-muted-foreground">{formatDate(user.createdAt)}</TableCell>
+                        <TableCell className="text-right">
+                          <div className="flex justify-end gap-2">
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              className="gap-2"
+                              onClick={() => handleEdit(user)}
+                            >
+                              <PencilLine className="h-4 w-4" />
+                              Edit
+                            </Button>
+                            <Button
+                              variant="destructive"
+                              size="sm"
+                              className="gap-2"
+                              onClick={() => setUserToDelete(user)}
+                              disabled={deleteMutation.isPending && userToDelete?.id === user.id}
+                            >
+                              {deleteMutation.isPending && userToDelete?.id === user.id ? (
+                                <Loader2 className="h-4 w-4 animate-spin" />
+                              ) : (
+                                <Trash2 className="h-4 w-4" />
+                              )}
+                              Delete
+                            </Button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+
+      <Dialog open={isEditOpen} onOpenChange={(open) => {
+        setEditOpen(open);
+        if (!open) {
+          setEditingUser(null);
+        }
+      }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit user</DialogTitle>
+            <DialogDescription>Update profile information or permissions for this user.</DialogDescription>
+          </DialogHeader>
+          <Form {...updateForm}>
+            <form
+              onSubmit={updateForm.handleSubmit((values) => updateMutation.mutate(values))}
+              className="space-y-4"
+            >
+              <FormField
+                control={updateForm.control}
+                name="fullName"
+                rules={{ required: "Full name is required" }}
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Full name</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Jane Doe" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={updateForm.control}
+                name="role"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Role</FormLabel>
+                    <Select onValueChange={field.onChange} value={field.value}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select a role" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {roleOptions.map((role) => (
+                          <SelectItem key={role} value={role}>
+                            {role}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={updateForm.control}
+                name="twoFactorEnabled"
+                render={({ field }) => (
+                  <FormItem className="flex items-center justify-between rounded-lg border border-border/60 bg-muted/20 px-4 py-3">
+                    <div>
+                      <FormLabel className="text-sm font-medium">Two-factor authentication</FormLabel>
+                      <FormDescription>Require a second factor when this user signs in.</FormDescription>
+                    </div>
+                    <FormControl>
+                      <Switch checked={field.value} onCheckedChange={field.onChange} />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+              <DialogFooter>
+                <Button type="submit" disabled={updateMutation.isPending} className="gap-2">
+                  {updateMutation.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
+                  Save changes
+                </Button>
+              </DialogFooter>
+            </form>
+          </Form>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog open={Boolean(userToDelete)} onOpenChange={(open) => !open && setUserToDelete(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete user</AlertDialogTitle>
+            <AlertDialogDescription>
+              This action will soft delete the user and prevent them from signing in. You can recreate the account later if
+              needed.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleteMutation.isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => userToDelete && deleteMutation.mutate(userToDelete.id)}
+              disabled={deleteMutation.isPending}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {deleteMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : "Delete"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </DashboardLayout>
+  );
+};
+
+export default AdminUsers;

--- a/src/pages/AdminUsers.tsx
+++ b/src/pages/AdminUsers.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 import { useForm } from "react-hook-form";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
@@ -208,28 +209,35 @@ const AdminUsers = () => {
           title="User management"
           description="Create, update, or deactivate workspace members. Only administrators can see this area."
           actions={(
-            <Dialog open={isCreateOpen} onOpenChange={(open) => {
-              setCreateOpen(open);
-              if (!open) {
-                createForm.reset(defaultCreateValues);
-              }
-            }}>
-              <DialogTrigger asChild>
-                <Button size="sm" className="gap-2 bg-gradient-primary text-white shadow-glow">
-                  <UserPlus className="h-4 w-4" />
-                  New user
-                </Button>
-              </DialogTrigger>
-              <DialogContent>
-                <DialogHeader>
-                  <DialogTitle>Create user</DialogTitle>
-                  <DialogDescription>Invite a new teammate with the appropriate role.</DialogDescription>
-                </DialogHeader>
-                <Form {...createForm}>
-                  <form
-                    onSubmit={createForm.handleSubmit((values) => createMutation.mutate(values))}
-                    className="space-y-4"
-                  >
+            <>
+              <Button variant="outline" size="sm" asChild>
+                <Link to="/admin">Admin panel</Link>
+              </Button>
+              <Dialog
+                open={isCreateOpen}
+                onOpenChange={(open) => {
+                  setCreateOpen(open);
+                  if (!open) {
+                    createForm.reset(defaultCreateValues);
+                  }
+                }}
+              >
+                <DialogTrigger asChild>
+                  <Button size="sm" className="gap-2 bg-gradient-primary text-white shadow-glow">
+                    <UserPlus className="h-4 w-4" />
+                    New user
+                  </Button>
+                </DialogTrigger>
+                <DialogContent>
+                  <DialogHeader>
+                    <DialogTitle>Create user</DialogTitle>
+                    <DialogDescription>Invite a new teammate with the appropriate role.</DialogDescription>
+                  </DialogHeader>
+                  <Form {...createForm}>
+                    <form
+                      onSubmit={createForm.handleSubmit((values) => createMutation.mutate(values))}
+                      className="space-y-4"
+                    >
                     <FormField
                       control={createForm.control}
                       name="fullName"
@@ -315,10 +323,11 @@ const AdminUsers = () => {
                         Create user
                       </Button>
                     </DialogFooter>
-                  </form>
-                </Form>
-              </DialogContent>
-            </Dialog>
+                    </form>
+                  </Form>
+                </DialogContent>
+              </Dialog>
+            </>
           )}
         />
 

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -89,13 +89,13 @@ const Settings = () => {
                 <div>
                   <CardTitle className="text-lg font-semibold text-foreground">Administrator tools</CardTitle>
                   <p className="text-sm text-muted-foreground">
-                    Access the workspace activity monitor to review every movement across the organization.
+                    Launch the control center to manage workspace members and review high-signal activity in one place.
                   </p>
                 </div>
               </CardHeader>
               <CardFooter className="flex justify-end">
                 <Button asChild className="bg-gradient-primary text-white shadow-glow">
-                  <Link to="/admin/activity">Open admin panel</Link>
+                  <Link to="/admin">Open admin panel</Link>
                 </Button>
               </CardFooter>
             </Card>


### PR DESCRIPTION
## Summary
- add soft-delete support to all domain entities and update repositories to respect the new `IsDeleted` flag
- extend user controller with admin-only create/update/delete endpoints and ensure deleted accounts cannot authenticate
- introduce an admin-only user management page with create, edit, and delete flows plus sidebar navigation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df9a0d4c7483318938f60608f6c69f